### PR TITLE
docs: add CLAUDE.md and Claude detail files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,28 @@
+# Bookshelf — Claude Instructions
+
+## Stack
+Expo (React Native + Web) · FastAPI · PostgreSQL · Render · GitHub Actions
+Monorepo: `backend/` · `frontend/` · `.github/` · `docs/`
+
+## Detail Files — Read Before Acting
+- [Git workflow](docs/claude/git.md)      ← READ THIS FIRST
+- [Backend](docs/claude/backend.md)
+- [Frontend](docs/claude/frontend.md)
+- [Testing](docs/claude/testing.md)
+
+## Hard Rules (no exceptions)
+1. NEVER push to `develop` or `main` directly.
+2. ALL work goes in `feature/<name>` or `bug/<name>` — branch from `develop`.
+3. After pushing: open a GitHub draft PR targeting `develop`.
+4. Run tests before marking any task done.
+5. No hardcoded colours — always use `useTheme()`.
+6. `SecureStore` only for tokens — never `AsyncStorage`.
+7. SQLAlchemy ORM only — no raw SQL.
+
+## Quick Commands
+```
+cd backend && uvicorn app.main:app --reload
+cd backend && pytest tests/ --cov=app
+cd frontend && npx expo start
+cd frontend && npx jest
+```

--- a/docs/claude/backend.md
+++ b/docs/claude/backend.md
@@ -1,0 +1,51 @@
+# Backend Conventions
+
+## Stack
+FastAPI · SQLAlchemy (async) · asyncpg · Alembic · pydantic-settings · httpx · slowapi
+
+## Running Locally
+
+```bash
+cd backend
+python -m venv .venv && source .venv/bin/activate   # Windows: .venv\Scripts\activate
+pip install -r requirements-dev.txt
+cp .env.example .env   # fill in your values
+alembic upgrade head
+uvicorn app.main:app --reload
+```
+
+## Key Patterns
+
+### Config
+All config loaded via `pydantic-settings` in `app/core/config.py`.
+Never hardcode env values — always use `settings.<key>`.
+
+### Database
+- Async session via `get_db()` dependency (`app/core/database.py`)
+- Always use `async with` — never call `.commit()` manually outside a transaction
+- SQLAlchemy ORM throughout — no raw SQL, ever
+
+### Routes
+- All routes (Phase 3+) require `get_current_user` FastAPI dependency
+- Pydantic schemas for every request and response body — no untyped dicts
+- Rate limit `/scan`: 10 req/min per user via slowapi
+- Max image upload: 5MB — enforce in the endpoint handler before processing
+
+### Auth
+- JWT RS256 only — reject all other algorithms including `none`
+- Allowlist check via `ALLOWED_EMAILS` env var after Google auth
+
+## Commands
+
+```bash
+# Tests
+pytest tests/ --cov=app --cov-fail-under=80
+
+# Lint + format
+ruff check .
+black --check .
+
+# Migrations
+alembic revision --autogenerate -m "description"
+alembic upgrade head
+```

--- a/docs/claude/frontend.md
+++ b/docs/claude/frontend.md
@@ -1,0 +1,50 @@
+# Frontend Conventions
+
+## Stack
+Expo SDK 51 · Expo Router · React Native · TypeScript · TanStack Query · axios · expo-secure-store
+
+## Running Locally
+
+```bash
+cd frontend
+npm install
+npx expo start
+# Press i (iOS), a (Android), or w (web)
+```
+
+## Key Patterns
+
+### Theme
+- **All colours must come from `useTheme()`** — zero hardcoded colour values, ever
+- Import: `import { useTheme } from '../hooks/useTheme'`
+- Use `theme.colors.*`, `theme.spacing.*`, `theme.typography.*`, `theme.radius.*`
+
+### Accessibility (WCAG 2.2 AA — required on every interactive element)
+```tsx
+<Pressable
+  accessibilityLabel="descriptive label (not just 'button')"
+  accessibilityRole="button"
+  accessibilityHint="what happens when activated (if non-obvious)"
+  style={{ minWidth: 44, minHeight: 44 }}  // WCAG 2.5.8
+>
+```
+
+### Token Storage
+- Tokens and preferences: `expo-secure-store` only
+- Never use `AsyncStorage` for anything sensitive
+
+### File Routing
+- Screens live in `app/` — Expo Router picks them up automatically
+- Tabs: `app/(tabs)/<name>.tsx`
+- Auth: `app/(auth)/<name>.tsx`
+- Modals: `app/<name>.tsx` with `presentation: 'modal'`
+
+## Commands
+
+```bash
+npx jest                          # unit tests
+npx jest --coverage               # with coverage report
+npx eslint .                      # lint (includes a11y rules)
+npx prettier --check .            # format check
+npx prettier --write .            # format fix
+```

--- a/docs/claude/git.md
+++ b/docs/claude/git.md
@@ -1,0 +1,59 @@
+# Git Workflow
+
+## Branch Strategy
+
+```
+feature/* ──┐
+            ├──→ develop ──→ main
+bug/*    ───┘
+```
+
+- `develop` and `main` are protected — **never push directly**
+- All work lives in a `feature/<name>` or `bug/<name>` branch
+- `develop` → `main` is a release-only operation performed by the user
+
+## Starting Work
+
+```bash
+git checkout develop
+git pull
+git checkout -b feature/<short-kebab-description>
+# or
+git checkout -b bug/<short-kebab-description>
+```
+
+## Commit Style
+
+Conventional commits:
+- `feat:` — new feature or behaviour
+- `fix:` — bug fix
+- `chore:` — tooling, deps, config (no production code change)
+- `test:` — adding or updating tests
+- `docs:` — documentation only
+- `refactor:` — code change that is neither a fix nor a feature
+
+Example: `feat: add BookIdentifierService abstract interface`
+
+## After Finishing Work
+
+```bash
+git push -u origin feature/<name>
+gh pr create --draft --base develop \
+  --title "feat: <description>" \
+  --body "$(cat <<'EOF'
+## Summary
+- <bullet points>
+
+## Test plan
+- [ ] <what to verify>
+
+🤖 Generated with Claude Code
+EOF
+)"
+```
+
+## Rules
+- Never use `--no-verify` or `--force` on protected branches
+- Delete the branch after the PR merges
+- Claude opens draft PRs — the user reviews, approves, and merges
+- Squash merge into `develop`; merge commit into `main`

--- a/docs/claude/testing.md
+++ b/docs/claude/testing.md
@@ -1,0 +1,62 @@
+# Testing Standards
+
+## Coverage Thresholds (enforced in CI)
+- Backend: 80% minimum (`--cov-fail-under=80`)
+- Frontend: 80% minimum (Jest `coverageThreshold`)
+
+## Backend
+
+### Test Structure
+```
+backend/tests/
+  unit/           → pure logic, no DB, no HTTP
+  integration/    → full request/response via httpx + real DB session
+  security/       → OWASP ZAP config, pen test scripts
+```
+
+### DB Isolation — Rollback Fixture (required for all DB tests)
+```python
+@pytest.fixture
+async def db_session():
+    async with engine.begin() as conn:
+        await conn.begin_nested()
+        session = AsyncSession(conn)
+        yield session
+        await conn.rollback()   # always rolls back — no state leaks between tests
+```
+
+- **Do NOT mock the database** in integration tests — use the real session + rollback
+- Each test gets a clean slate via rollback, not truncation
+
+### Running
+```bash
+pytest tests/ --cov=app --cov-fail-under=80
+pytest tests/unit/          # unit only
+pytest tests/integration/   # integration only
+```
+
+## Frontend
+
+### Test Structure
+```
+frontend/__tests__/
+  unit/    → components, hooks, utilities (Jest + React Native Testing Library)
+  e2e/     → full app flows (Detox — runs on PRs to main only)
+```
+
+### Patterns
+- Use `@testing-library/react-native` queries — prefer accessible queries (`getByRole`, `getByLabelText`) over `getByTestId`
+- Wrap components in `ThemeProvider` for any component that calls `useTheme()`
+- Mock `expo-secure-store` in unit tests
+
+### Running
+```bash
+npx jest                     # all unit tests
+npx jest --coverage          # with report
+npx jest __tests__/unit/     # unit only
+```
+
+## CI Enforcement
+- Unit + integration tests: every PR to `develop` and `main`
+- E2E (Detox): PRs to `main` only
+- OWASP ZAP baseline: post-deploy to staging (in `deploy.yml`)


### PR DESCRIPTION
- CLAUDE.md (28 lines): stack overview, hard rules, quick commands, pointers to detail files
- docs/claude/git.md: branch strategy, commit style, PR workflow, protected branch rules
- docs/claude/backend.md: FastAPI conventions, run/test commands, key patterns
- docs/claude/frontend.md: Expo conventions, theme/a11y rules, run/test commands
- docs/claude/testing.md: coverage thresholds, rollback fixture pattern, test structure