### PR TITLE
feat(phase-3): Google SSO auth backend + Expo login screen

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -1,0 +1,104 @@
+import uuid
+
+import jwt
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.dependencies import get_current_user
+from app.auth.google import verify_google_id_token
+from app.auth.jwt import create_access_token, create_refresh_token, decode_token
+from app.core.config import settings
+from app.core.database import get_db
+from app.models.user import User
+from app.schemas.auth import GoogleAuthRequest, RefreshRequest, TokenResponse, UserRead
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+@router.post("/google", response_model=TokenResponse)
+async def google_auth(
+    body: GoogleAuthRequest, db: AsyncSession = Depends(get_db)
+) -> TokenResponse:
+    try:
+        claims = await verify_google_id_token(body.id_token)
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid Google token"
+        )
+
+    email: str = claims.get("email", "")
+    if not claims.get("email_verified"):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Google email not verified"
+        )
+
+    if settings.allowed_emails_list and email not in settings.allowed_emails_list:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Email not authorized"
+        )
+
+    result = await db.execute(select(User).where(User.email == email))
+    user = result.scalar_one_or_none()
+    if user is None:
+        user = User(
+            email=email,
+            google_id=claims.get("sub", ""),
+            display_name=claims.get("name"),
+            avatar_url=claims.get("picture"),
+        )
+        db.add(user)
+    else:
+        user.display_name = claims.get("name")
+        user.avatar_url = claims.get("picture")
+
+    await db.commit()
+    await db.refresh(user)
+
+    access_token = create_access_token(str(user.id), user.email)
+    refresh_token = create_refresh_token(str(user.id))
+    return TokenResponse(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        expires_in=settings.jwt_expiry_hours * 3600,
+    )
+
+
+@router.post("/refresh", response_model=TokenResponse)
+async def refresh(
+    body: RefreshRequest, db: AsyncSession = Depends(get_db)
+) -> TokenResponse:
+    try:
+        payload = decode_token(body.refresh_token)
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Refresh token expired"
+        )
+    except jwt.InvalidTokenError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid refresh token"
+        )
+
+    if payload.get("type") != "refresh":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token type"
+        )
+
+    user = await db.get(User, uuid.UUID(payload["sub"]))
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found"
+        )
+
+    access_token = create_access_token(str(user.id), user.email)
+    new_refresh = create_refresh_token(str(user.id))
+    return TokenResponse(
+        access_token=access_token,
+        refresh_token=new_refresh,
+        expires_in=settings.jwt_expiry_hours * 3600,
+    )
+
+
+@router.get("/me", response_model=UserRead)
+async def get_me(current_user: User = Depends(get_current_user)) -> User:
+    return current_user

--- a/backend/app/auth/dependencies.py
+++ b/backend/app/auth/dependencies.py
@@ -1,0 +1,41 @@
+import uuid
+
+import jwt
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.jwt import decode_token
+from app.core.database import get_db
+from app.models.user import User
+
+_bearer = HTTPBearer()
+
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(_bearer),
+    db: AsyncSession = Depends(get_db),
+) -> User:
+    token = credentials.credentials
+    try:
+        payload = decode_token(token)
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Token expired"
+        )
+    except jwt.InvalidTokenError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+        )
+
+    if payload.get("type") != "access":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token type"
+        )
+
+    user = await db.get(User, uuid.UUID(payload["sub"]))
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found"
+        )
+    return user

--- a/backend/app/auth/google.py
+++ b/backend/app/auth/google.py
@@ -1,0 +1,31 @@
+import httpx
+from authlib.jose import jwt as authlib_jwt
+
+from app.core.config import settings
+
+GOOGLE_CERTS_URL = "https://www.googleapis.com/oauth2/v3/certs"
+
+
+async def verify_google_id_token(id_token: str) -> dict:
+    """Verify a Google ID token against Google's JWKS and return its claims."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(GOOGLE_CERTS_URL)
+        resp.raise_for_status()
+        jwks = resp.json()
+
+    claims = authlib_jwt.decode(
+        id_token,
+        jwks,
+        claims_options={
+            "iss": {
+                "essential": True,
+                "values": ["https://accounts.google.com"],
+            },
+            "aud": {
+                "essential": True,
+                "value": settings.google_client_id,
+            },
+        },
+    )
+    claims.validate()
+    return dict(claims)

--- a/backend/app/auth/jwt.py
+++ b/backend/app/auth/jwt.py
@@ -1,0 +1,33 @@
+from datetime import datetime, timedelta, timezone
+
+import jwt
+
+from app.core.config import settings
+
+
+def create_access_token(user_id: str, email: str) -> str:
+    now = datetime.now(timezone.utc)
+    payload = {
+        "sub": user_id,
+        "email": email,
+        "iat": now,
+        "exp": now + timedelta(hours=settings.jwt_expiry_hours),
+        "type": "access",
+    }
+    return jwt.encode(payload, settings.jwt_private_key, algorithm="RS256")
+
+
+def create_refresh_token(user_id: str) -> str:
+    now = datetime.now(timezone.utc)
+    payload = {
+        "sub": user_id,
+        "iat": now,
+        "exp": now + timedelta(days=settings.refresh_token_expiry_days),
+        "type": "refresh",
+    }
+    return jwt.encode(payload, settings.jwt_private_key, algorithm="RS256")
+
+
+def decode_token(token: str) -> dict:
+    """Decode and verify a JWT. Raises jwt.InvalidTokenError subclasses on failure."""
+    return jwt.decode(token, settings.jwt_public_key, algorithms=["RS256"])

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from app.api.auth import router as auth_router
 from app.core.config import settings
 
 app = FastAPI(
@@ -17,6 +18,9 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+app.include_router(auth_router)
 
 
 @app.get("/health")

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -9,8 +9,7 @@ from pydantic import BaseModel
 class GoogleAuthRequest(BaseModel):
     """Body for POST /auth/google."""
 
-    code: str
-    redirect_uri: str
+    id_token: str
 
 
 class TokenResponse(BaseModel):

--- a/backend/tests/unit/test_auth_jwt.py
+++ b/backend/tests/unit/test_auth_jwt.py
@@ -1,0 +1,128 @@
+"""Unit tests for JWT token creation and decoding (no DB required)."""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from app.auth.jwt import create_access_token, create_refresh_token, decode_token
+
+
+@pytest.fixture(scope="module")
+def rsa_key_pair():
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = private_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    public_pem = (
+        private_key.public_key()
+        .public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode()
+    )
+    return private_pem, public_pem
+
+
+@pytest.fixture(autouse=True)
+def patch_settings(rsa_key_pair):
+    private_pem, public_pem = rsa_key_pair
+    with patch("app.auth.jwt.settings") as mock:
+        mock.jwt_private_key = private_pem
+        mock.jwt_public_key = public_pem
+        mock.jwt_expiry_hours = 24
+        mock.refresh_token_expiry_days = 7
+        yield mock
+
+
+class TestCreateAccessToken:
+    def test_contains_correct_claims(self, rsa_key_pair):
+        _, public_pem = rsa_key_pair
+        token = create_access_token("user-abc", "user@example.com")
+        payload = jwt.decode(token, public_pem, algorithms=["RS256"])
+        assert payload["sub"] == "user-abc"
+        assert payload["email"] == "user@example.com"
+        assert payload["type"] == "access"
+
+    def test_uses_rs256_algorithm(self, rsa_key_pair):
+        _, public_pem = rsa_key_pair
+        token = create_access_token("user-abc", "user@example.com")
+        header = jwt.get_unverified_header(token)
+        assert header["alg"] == "RS256"
+
+    def test_expiry_matches_settings(self, rsa_key_pair, patch_settings):
+        _, public_pem = rsa_key_pair
+        patch_settings.jwt_expiry_hours = 2
+        token = create_access_token("u", "e@x.com")
+        payload = jwt.decode(token, public_pem, algorithms=["RS256"])
+        now = datetime.now(timezone.utc)
+        exp = datetime.fromtimestamp(payload["exp"], tz=timezone.utc)
+        delta = exp - now
+        assert 1.9 * 3600 < delta.total_seconds() < 2.1 * 3600
+
+
+class TestCreateRefreshToken:
+    def test_contains_correct_claims(self, rsa_key_pair):
+        _, public_pem = rsa_key_pair
+        token = create_refresh_token("user-xyz")
+        payload = jwt.decode(token, public_pem, algorithms=["RS256"])
+        assert payload["sub"] == "user-xyz"
+        assert payload["type"] == "refresh"
+
+    def test_refresh_has_no_email_claim(self, rsa_key_pair):
+        _, public_pem = rsa_key_pair
+        token = create_refresh_token("user-xyz")
+        payload = jwt.decode(token, public_pem, algorithms=["RS256"])
+        assert "email" not in payload
+
+    def test_expiry_matches_settings(self, rsa_key_pair, patch_settings):
+        _, public_pem = rsa_key_pair
+        patch_settings.refresh_token_expiry_days = 3
+        token = create_refresh_token("u")
+        payload = jwt.decode(token, public_pem, algorithms=["RS256"])
+        now = datetime.now(timezone.utc)
+        exp = datetime.fromtimestamp(payload["exp"], tz=timezone.utc)
+        delta = exp - now
+        assert 2.9 * 86400 < delta.total_seconds() < 3.1 * 86400
+
+
+class TestDecodeToken:
+    def test_decodes_valid_access_token(self, rsa_key_pair):
+        token = create_access_token("u1", "a@b.com")
+        payload = decode_token(token)
+        assert payload["sub"] == "u1"
+        assert payload["type"] == "access"
+
+    def test_decodes_valid_refresh_token(self):
+        token = create_refresh_token("u2")
+        payload = decode_token(token)
+        assert payload["sub"] == "u2"
+        assert payload["type"] == "refresh"
+
+    def test_raises_on_expired_token(self, rsa_key_pair):
+        private_pem, _ = rsa_key_pair
+        payload = {
+            "sub": "u",
+            "type": "access",
+            "exp": datetime.now(timezone.utc) - timedelta(seconds=1),
+            "iat": datetime.now(timezone.utc) - timedelta(hours=1),
+        }
+        expired_token = jwt.encode(payload, private_pem, algorithm="RS256")
+        with pytest.raises(jwt.ExpiredSignatureError):
+            decode_token(expired_token)
+
+    def test_raises_on_tampered_token(self, rsa_key_pair):
+        token = create_access_token("u", "e@x.com")
+        tampered = token[:-5] + "XXXXX"
+        with pytest.raises(jwt.InvalidTokenError):
+            decode_token(tampered)
+
+    def test_raises_on_garbage_input(self):
+        with pytest.raises(jwt.InvalidTokenError):
+            decode_token("not.a.token")

--- a/frontend/app/(auth)/login.tsx
+++ b/frontend/app/(auth)/login.tsx
@@ -1,8 +1,29 @@
-import { View, Text, StyleSheet } from 'react-native';
+import { useEffect } from 'react';
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
+import * as Google from 'expo-auth-session/providers/google';
+import * as WebBrowser from 'expo-web-browser';
+
+import { useAuth } from '../../hooks/useAuth';
 import { useTheme } from '../../hooks/useTheme';
+
+WebBrowser.maybeCompleteAuthSession();
 
 export default function LoginScreen() {
   const { theme } = useTheme();
+  const { login } = useAuth();
+
+  const [request, response, promptAsync] = Google.useIdTokenAuthRequest({
+    clientId: process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID,
+    iosClientId: process.env.EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID,
+    androidClientId: process.env.EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID,
+  });
+
+  useEffect(() => {
+    if (response?.type === 'success') {
+      const { id_token } = response.params;
+      login(id_token).catch(console.error);
+    }
+  }, [response, login]);
 
   return (
     <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
@@ -12,7 +33,29 @@ export default function LoginScreen() {
       >
         Bookshelf
       </Text>
-      {/* Google SSO — Phase 3 */}
+      <Pressable
+        style={[
+          styles.button,
+          {
+            backgroundColor: theme.colors.primary,
+            marginTop: theme.spacing.xl,
+            opacity: request ? 1 : 0.6,
+          },
+        ]}
+        onPress={() => promptAsync()}
+        disabled={!request}
+        accessibilityLabel="Sign in with Google"
+        accessibilityRole="button"
+        accessibilityHint="Opens Google sign-in to access your bookshelf"
+      >
+        {!request ? (
+          <ActivityIndicator color="#FFFFFF" />
+        ) : (
+          <Text style={{ color: '#FFFFFF', fontWeight: theme.typography.fontWeightBold }}>
+            Sign in with Google
+          </Text>
+        )}
+      </Pressable>
     </View>
   );
 }
@@ -20,6 +63,15 @@ export default function LoginScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  button: {
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 8,
+    minWidth: 220,
+    minHeight: 44,
     alignItems: 'center',
     justifyContent: 'center',
   },

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -1,15 +1,19 @@
 import { Stack } from 'expo-router';
-import { ThemeProvider } from '../theme';
+
 import { ThemeToggleButton } from '../components/ThemeToggleButton';
+import { AuthProvider } from '../contexts/AuthContext';
+import { ThemeProvider } from '../theme';
 
 export default function RootLayout() {
   return (
     <ThemeProvider>
-      <Stack
-        screenOptions={{
-          headerRight: () => <ThemeToggleButton />,
-        }}
-      />
+      <AuthProvider>
+        <Stack
+          screenOptions={{
+            headerRight: () => <ThemeToggleButton />,
+          }}
+        />
+      </AuthProvider>
     </ThemeProvider>
   );
 }

--- a/frontend/contexts/AuthContext.tsx
+++ b/frontend/contexts/AuthContext.tsx
@@ -1,0 +1,64 @@
+import React, { createContext, useCallback, useEffect, useState } from 'react';
+import { useRouter, useSegments } from 'expo-router';
+import * as SecureStore from 'expo-secure-store';
+
+import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY, api } from '../lib/api';
+
+interface AuthContextValue {
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  login: (idToken: string) => Promise<void>;
+  logout: () => Promise<void>;
+}
+
+export const AuthContext = createContext<AuthContextValue>({
+  isAuthenticated: false,
+  isLoading: true,
+  login: async () => {},
+  logout: async () => {},
+});
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const segments = useSegments();
+  const router = useRouter();
+
+  // Check for stored token on mount
+  useEffect(() => {
+    SecureStore.getItemAsync(ACCESS_TOKEN_KEY).then((token) => {
+      setIsAuthenticated(!!token);
+      setIsLoading(false);
+    });
+  }, []);
+
+  // Redirect based on auth state
+  useEffect(() => {
+    if (isLoading) return;
+    const inAuthGroup = segments[0] === '(auth)';
+    if (!isAuthenticated && !inAuthGroup) {
+      router.replace('/(auth)/login');
+    } else if (isAuthenticated && inAuthGroup) {
+      router.replace('/(tabs)');
+    }
+  }, [isAuthenticated, isLoading, segments, router]);
+
+  const login = useCallback(async (idToken: string) => {
+    const { data } = await api.post('/auth/google', { id_token: idToken });
+    await SecureStore.setItemAsync(ACCESS_TOKEN_KEY, data.access_token);
+    await SecureStore.setItemAsync(REFRESH_TOKEN_KEY, data.refresh_token);
+    setIsAuthenticated(true);
+  }, []);
+
+  const logout = useCallback(async () => {
+    await SecureStore.deleteItemAsync(ACCESS_TOKEN_KEY);
+    await SecureStore.deleteItemAsync(REFRESH_TOKEN_KEY);
+    setIsAuthenticated(false);
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ isAuthenticated, isLoading, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/frontend/hooks/useAuth.ts
+++ b/frontend/hooks/useAuth.ts
@@ -1,0 +1,7 @@
+import { useContext } from 'react';
+
+import { AuthContext } from '../contexts/AuthContext';
+
+export function useAuth() {
+  return useContext(AuthContext);
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,0 +1,48 @@
+import axios from 'axios';
+import * as SecureStore from 'expo-secure-store';
+
+const BASE_URL = process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:8000';
+
+export const ACCESS_TOKEN_KEY = 'bookshelf_access_token';
+export const REFRESH_TOKEN_KEY = 'bookshelf_refresh_token';
+
+export const api = axios.create({
+  baseURL: BASE_URL,
+  headers: { 'Content-Type': 'application/json' },
+});
+
+// Inject access token on every request
+api.interceptors.request.use(async (config) => {
+  const token = await SecureStore.getItemAsync(ACCESS_TOKEN_KEY);
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+// On 401: attempt token refresh once, then give up
+api.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const original = error.config;
+    if (error.response?.status === 401 && !original._retry) {
+      original._retry = true;
+      const refreshToken = await SecureStore.getItemAsync(REFRESH_TOKEN_KEY);
+      if (refreshToken) {
+        try {
+          const { data } = await axios.post(`${BASE_URL}/auth/refresh`, {
+            refresh_token: refreshToken,
+          });
+          await SecureStore.setItemAsync(ACCESS_TOKEN_KEY, data.access_token);
+          await SecureStore.setItemAsync(REFRESH_TOKEN_KEY, data.refresh_token);
+          original.headers.Authorization = `Bearer ${data.access_token}`;
+          return api(original);
+        } catch {
+          await SecureStore.deleteItemAsync(ACCESS_TOKEN_KEY);
+          await SecureStore.deleteItemAsync(REFRESH_TOKEN_KEY);
+        }
+      }
+    }
+    return Promise.reject(error);
+  }
+);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "axios": "^1.7.7",
     "expo": "~51.0.28",
     "expo-auth-session": "~5.5.2",
+    "expo-web-browser": "~13.0.3",
     "expo-camera": "~15.0.16",
     "expo-router": "~3.5.23",
     "expo-secure-store": "~13.0.2",


### PR DESCRIPTION
Backend:
- app/auth/jwt.py: RS256 access + refresh token creation/decoding via PyJWT
- app/auth/google.py: Google ID token verification via authlib JWKS
- app/auth/dependencies.py: get_current_user FastAPI dependency (HTTPBearer)
- app/api/auth.py: POST /auth/google, POST /auth/refresh, GET /auth/me
- schemas/auth.py: GoogleAuthRequest uses id_token (ID token flow)
- main.py: register auth router
- tests/unit/test_auth_jwt.py: 11 JWT unit tests (create/decode/expiry/tamper)

Frontend:
- lib/api.ts: axios instance with Bearer injection + 401 refresh interceptor
- contexts/AuthContext.tsx: auth state, SecureStore persistence, redirect logic
- hooks/useAuth.ts: thin useContext wrapper
- app/(auth)/login.tsx: Google sign-in via expo-auth-session useIdTokenAuthRequest
- app/_layout.tsx: wrap Stack in AuthProvider
- package.json: add expo-web-browser ~13.0.3