### PR TITLE
fix(config): normalize DATABASE_URL for asyncpg

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -10,7 +10,7 @@ from app.core.database import Base  # noqa: F401
 import app.models  # noqa: F401 — registers all models with Base.metadata
 
 config = context.config
-config.set_main_option("sqlalchemy.url", settings.database_url)
+config.set_main_option("sqlalchemy.url", settings.async_database_url)
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -27,6 +27,11 @@ class Settings(BaseSettings):
     rate_limit_scan: str = "10/minute"
 
     @property
+    def async_database_url(self) -> str:
+        # Render injects postgres:// but asyncpg requires postgresql+asyncpg://
+        return self.database_url.replace("postgres://", "postgresql+asyncpg://", 1)
+
+    @property
     def allowed_emails_list(self) -> list[str]:
         return [e.strip() for e in self.allowed_emails.split(",") if e.strip()]
 

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import DeclarativeBase
 
 from app.core.config import settings
 
-engine = create_async_engine(settings.database_url, echo=False)
+engine = create_async_engine(settings.async_database_url, echo=False)
 AsyncSessionLocal = async_sessionmaker(engine, expire_on_commit=False)
 
 


### PR DESCRIPTION
Render injects postgres:// but SQLAlchemy asyncpg driver requires postgresql+asyncpg://. Added async_database_url property to Settings and updated database.py and alembic/env.py to use it.