### PR TITLE
fix: normalize postgresql:// URL scheme for asyncpg

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -28,8 +28,10 @@ class Settings(BaseSettings):
 
     @property
     def async_database_url(self) -> str:
-        # Render injects postgres:// but asyncpg requires postgresql+asyncpg://
-        return self.database_url.replace("postgres://", "postgresql+asyncpg://", 1)
+        # Normalize any postgres:// or postgresql:// scheme to postgresql+asyncpg://
+        import re
+
+        return re.sub(r"^postgres(ql)?://", "postgresql+asyncpg://", self.database_url)
 
     @property
     def allowed_emails_list(self) -> list[str]:


### PR DESCRIPTION
Render injects \`postgresql://\` but our \`async_database_url\` property only replaced \`postgres://\`, making it a no-op. Alembic and SQLAlchemy were then trying to connect with the wrong driver scheme, causing pre_deploy_failed.

Fix: use regex to normalize both \`postgres://\` and \`postgresql://\` to \`postgresql+asyncpg://\`.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>