### PR TITLE
test: LoginScreen, API interceptor, JWT security, and ownership tests

### DIFF
--- a/backend/tests/unit/test_auth_jwt.py
+++ b/backend/tests/unit/test_auth_jwt.py
@@ -126,3 +126,79 @@ class TestDecodeToken:
     def test_raises_on_garbage_input(self):
         with pytest.raises(jwt.InvalidTokenError):
             decode_token("not.a.token")
+
+
+# ─── Security: algorithm attacks ──────────────────────────────────────────────
+
+
+class TestAlgorithmSecurity:
+    """Verify decode_token rejects tokens using unexpected algorithms."""
+
+    def test_rejects_alg_none(self, rsa_key_pair):
+        """'alg: none' unsigned tokens must never be accepted."""
+        private_pem, _ = rsa_key_pair
+        payload = {
+            "sub": "attacker",
+            "type": "access",
+            "exp": datetime.now(timezone.utc) + timedelta(hours=1),
+            "iat": datetime.now(timezone.utc),
+        }
+        # PyJWT refuses to encode with alg=none; craft the token manually.
+        import base64
+        import json
+
+        header = base64.urlsafe_b64encode(
+            json.dumps({"alg": "none", "typ": "JWT"}).encode()
+        ).rstrip(b"=")
+        body = base64.urlsafe_b64encode(
+            json.dumps(
+                {
+                    **payload,
+                    "exp": int(payload["exp"].timestamp()),
+                    "iat": int(payload["iat"].timestamp()),
+                }
+            ).encode()
+        ).rstrip(b"=")
+        none_token = f"{header.decode()}.{body.decode()}."
+
+        with pytest.raises(jwt.InvalidTokenError):
+            decode_token(none_token)
+
+    def test_rejects_hs256_token(self):
+        """
+        Algorithm confusion: decode_token must reject any HS256-signed token
+        because it only accepts RS256. An attacker can't forge a valid RS256
+        token, but they could try submitting an HS256 one.
+        """
+        payload = {
+            "sub": "attacker",
+            "type": "access",
+            "exp": datetime.now(timezone.utc) + timedelta(hours=1),
+            "iat": datetime.now(timezone.utc),
+        }
+        hs256_token = jwt.encode(payload, "any-hmac-secret", algorithm="HS256")
+
+        with pytest.raises(jwt.InvalidTokenError):
+            decode_token(hs256_token)
+
+    def test_rejects_token_signed_with_different_private_key(self):
+        """Token signed with a different RSA key must not verify."""
+        from cryptography.hazmat.primitives.asymmetric import rsa as _rsa
+
+        other_key = _rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        other_private_pem = other_key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        ).decode()
+
+        payload = {
+            "sub": "user",
+            "type": "access",
+            "exp": datetime.now(timezone.utc) + timedelta(hours=1),
+            "iat": datetime.now(timezone.utc),
+        }
+        foreign_token = jwt.encode(payload, other_private_pem, algorithm="RS256")
+
+        with pytest.raises(jwt.InvalidTokenError):
+            decode_token(foreign_token)

--- a/backend/tests/unit/test_user_books_endpoint.py
+++ b/backend/tests/unit/test_user_books_endpoint.py
@@ -184,6 +184,60 @@ class TestUpdateUserBook:
         assert resp.status_code == 404
 
 
+# ─── PATCH /user-books/{id} — ownership ───────────────────────────────────────
+
+
+class TestUpdateUserBookOwnership:
+    """The endpoint filters by user_id, so another user's book is invisible."""
+
+    def test_returns_404_when_book_belongs_to_different_user(self):
+        """
+        A user attempting to PATCH a user_book they don't own gets 404.
+        The query is scoped to current_user.id, so the record is simply
+        not found — ownership is enforced implicitly by the DB query.
+        """
+        OTHER_USER = User(
+            id=uuid.UUID("99999999-9999-9999-9999-999999999999"),
+            email="other@example.com",
+        )
+
+        async def _fake_db_empty():
+            db = AsyncMock()
+            db.execute = AsyncMock(return_value=_none_result())
+            yield db
+
+        from app.auth.dependencies import get_current_user
+        from app.core.database import get_db
+
+        app.dependency_overrides[get_current_user] = lambda: OTHER_USER
+        app.dependency_overrides[get_db] = _fake_db_empty
+        resp = TestClient(app).patch(
+            f"/user-books/{USER_BOOK_ID}", json={"status": "purchased"}
+        )
+        app.dependency_overrides.clear()
+        assert resp.status_code == 404
+
+    def test_returns_404_when_deleting_book_belonging_to_different_user(self):
+        OTHER_USER = User(
+            id=uuid.UUID("99999999-9999-9999-9999-999999999999"),
+            email="other@example.com",
+        )
+
+        async def _fake_db_empty():
+            db = AsyncMock()
+            db.execute = AsyncMock(return_value=_none_result())
+            yield db
+
+        from app.auth.dependencies import get_current_user
+        from app.core.database import get_db
+
+        app.dependency_overrides[get_current_user] = lambda: OTHER_USER
+        app.dependency_overrides[get_db] = _fake_db_empty
+        resp = TestClient(app).delete(f"/user-books/{USER_BOOK_ID}")
+        app.dependency_overrides.clear()
+        assert resp.status_code == 404
+
+
 # ─── DELETE /user-books/{id} ──────────────────────────────────────────────────
 
 

--- a/frontend/__tests__/unit/LoginScreen.test.tsx
+++ b/frontend/__tests__/unit/LoginScreen.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+
+import LoginScreen from '../../app/(auth)/login';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockLogin = jest.fn();
+jest.mock('../../hooks/useAuth', () => ({
+  useAuth: () => ({ login: mockLogin }),
+}));
+
+jest.mock('../../hooks/useTheme', () => ({
+  useTheme: () => ({
+    theme: {
+      colors: {
+        background: '#fff',
+        text: '#111',
+        primary: '#2563EB',
+      },
+      typography: {
+        fontSizeXL: 24,
+        fontWeightBold: '700',
+      },
+      spacing: { xl: 32 },
+    },
+  }),
+}));
+
+jest.mock('expo-web-browser', () => ({
+  maybeCompleteAuthSession: jest.fn(),
+}));
+
+const mockPromptAsync = jest.fn();
+
+jest.mock('expo-auth-session/providers/google', () => ({
+  useIdTokenAuthRequest: jest.fn(),
+}));
+
+function setupGoogleAuth(
+  opts: { request?: object | null; response?: object | null } = {}
+) {
+  const { useIdTokenAuthRequest } = require('expo-auth-session/providers/google');
+  // Use 'in' check so callers can explicitly pass null to simulate no request yet
+  const requestValue = 'request' in opts ? opts.request : { clientId: 'test' };
+  const responseValue = 'response' in opts ? opts.response : null;
+  useIdTokenAuthRequest.mockReturnValue([requestValue, responseValue, mockPromptAsync]);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setupGoogleAuth();
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('LoginScreen', () => {
+  it('renders the app title', () => {
+    const { getByText } = render(<LoginScreen />);
+    expect(getByText('Bookshelf')).toBeTruthy();
+  });
+
+  it('renders Sign in button when request is ready', () => {
+    const { getByLabelText } = render(<LoginScreen />);
+    expect(getByLabelText('Sign in with Google')).toBeTruthy();
+  });
+
+  it('shows Sign in text when request is truthy', () => {
+    const { getByText } = render(<LoginScreen />);
+    expect(getByText('Sign in with Google')).toBeTruthy();
+  });
+
+  it('shows ActivityIndicator when request is not yet ready', () => {
+    setupGoogleAuth({ request: null });
+    const { queryByText, getByLabelText } = render(<LoginScreen />);
+    // Button label is still present (for accessibility) but text content is a spinner
+    expect(queryByText('Sign in with Google')).toBeNull();
+    expect(getByLabelText('Sign in with Google')).toBeTruthy();
+  });
+
+  it('button is disabled when request is null', () => {
+    setupGoogleAuth({ request: null });
+    const { getByLabelText } = render(<LoginScreen />);
+    const btn = getByLabelText('Sign in with Google');
+    expect(btn.props.accessibilityState?.disabled ?? btn.props.disabled).toBeTruthy();
+  });
+
+  it('calls promptAsync when button pressed', () => {
+    const { getByLabelText } = render(<LoginScreen />);
+    fireEvent.press(getByLabelText('Sign in with Google'));
+    expect(mockPromptAsync).toHaveBeenCalled();
+  });
+
+  it('calls login with id_token when Google response is success', async () => {
+    setupGoogleAuth({
+      response: { type: 'success', params: { id_token: 'google-id-token-abc' } },
+    });
+    mockLogin.mockResolvedValue(undefined);
+    render(<LoginScreen />);
+    await waitFor(() =>
+      expect(mockLogin).toHaveBeenCalledWith('google-id-token-abc')
+    );
+  });
+
+  it('does not call login when response type is not success', async () => {
+    setupGoogleAuth({ response: { type: 'dismiss' } });
+    render(<LoginScreen />);
+    await waitFor(() => expect(mockLogin).not.toHaveBeenCalled());
+  });
+
+  it('does not call login when response is null', async () => {
+    setupGoogleAuth({ response: null });
+    render(<LoginScreen />);
+    await waitFor(() => expect(mockLogin).not.toHaveBeenCalled());
+  });
+});

--- a/frontend/__tests__/unit/api.test.ts
+++ b/frontend/__tests__/unit/api.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for the axios instance in lib/api.ts.
+ *
+ * We exercise the request interceptor (token injection) and the response
+ * interceptor (401 → refresh → retry, and failure paths) without making
+ * real HTTP calls.
+ */
+
+const mockGetItem = jest.fn();
+const mockSetItem = jest.fn();
+const mockDeleteItem = jest.fn();
+
+jest.mock('../../lib/storage', () => ({
+  getItem: (...args: unknown[]) => mockGetItem(...args),
+  setItem: (...args: unknown[]) => mockSetItem(...args),
+  deleteItem: (...args: unknown[]) => mockDeleteItem(...args),
+}));
+
+// Mock axios.post used in the refresh leg of the interceptor.
+// We leave the axios instance itself intact so interceptors run normally.
+const mockAxiosPost = jest.fn();
+jest.mock('axios', () => {
+  const actual = jest.requireActual('axios');
+  return {
+    ...actual,
+    // Override the standalone axios.post (used by the refresh call)
+    post: (...args: unknown[]) => mockAxiosPost(...args),
+    create: actual.create,
+  };
+});
+
+import { ACCESS_TOKEN_KEY, api, REFRESH_TOKEN_KEY } from '../../lib/api';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function make401Error(config: object = {}) {
+  return {
+    response: { status: 401 },
+    config: { headers: {}, ...config },
+  };
+}
+
+function makeNetworkError() {
+  return { request: {}, message: 'Network Error' }; // no .response
+}
+
+// Pull the interceptors out of the axios instance so we can invoke them directly
+const requestHandlers = (api.interceptors.request as any).handlers;
+const responseHandlers = (api.interceptors.response as any).handlers;
+
+async function runRequestInterceptor(config: object = { headers: {} }) {
+  const fulfilled = requestHandlers[0]?.fulfilled;
+  return fulfilled(config);
+}
+
+async function runResponseErrorInterceptor(error: object) {
+  const rejected = responseHandlers[0]?.rejected;
+  return rejected(error);
+}
+
+// ─── Request interceptor — token injection ────────────────────────────────────
+
+describe('api request interceptor', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('injects Authorization header when token exists', async () => {
+    mockGetItem.mockResolvedValue('my-access-token');
+    const config = { headers: {} as Record<string, string> };
+    const result = await runRequestInterceptor(config);
+    expect(result.headers.Authorization).toBe('Bearer my-access-token');
+  });
+
+  it('leaves Authorization header absent when no token', async () => {
+    mockGetItem.mockResolvedValue(null);
+    const config = { headers: {} as Record<string, string> };
+    const result = await runRequestInterceptor(config);
+    expect(result.headers.Authorization).toBeUndefined();
+  });
+
+  it('reads from ACCESS_TOKEN_KEY', async () => {
+    mockGetItem.mockResolvedValue(null);
+    await runRequestInterceptor({ headers: {} });
+    expect(mockGetItem).toHaveBeenCalledWith(ACCESS_TOKEN_KEY);
+  });
+});
+
+// ─── Response interceptor — 401 handling ─────────────────────────────────────
+
+describe('api response interceptor — 401 handling', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('passes non-401 errors through unchanged', async () => {
+    const err = { response: { status: 500 }, config: {} };
+    await expect(runResponseErrorInterceptor(err)).rejects.toEqual(err);
+  });
+
+  it('passes network errors (no response) through unchanged', async () => {
+    const err = makeNetworkError();
+    await expect(runResponseErrorInterceptor(err)).rejects.toEqual(err);
+  });
+
+  it('does not retry when _retry flag already set', async () => {
+    const err = make401Error({ _retry: true });
+    await expect(runResponseErrorInterceptor(err)).rejects.toBeDefined();
+    expect(mockAxiosPost).not.toHaveBeenCalled();
+  });
+
+  it('does not call refresh when no refresh token stored', async () => {
+    mockGetItem.mockResolvedValue(null); // no refresh token
+    const err = make401Error();
+    await expect(runResponseErrorInterceptor(err)).rejects.toBeDefined();
+    expect(mockAxiosPost).not.toHaveBeenCalled();
+  });
+
+  it('calls POST /auth/refresh with stored refresh token', async () => {
+    mockGetItem.mockImplementation((key: string) =>
+      key === REFRESH_TOKEN_KEY ? Promise.resolve('old-refresh') : Promise.resolve(null)
+    );
+    mockAxiosPost.mockResolvedValue({
+      data: { access_token: 'new-access', refresh_token: 'new-refresh' },
+    });
+
+    // The interceptor calls api(original) to retry — that will fail with a
+    // network error in Jest (no HTTP server). Absorb it; we only care that
+    // the refresh POST and token storage happened first.
+    await runResponseErrorInterceptor(make401Error()).catch(() => {});
+
+    expect(mockAxiosPost).toHaveBeenCalledWith(
+      expect.stringContaining('/auth/refresh'),
+      { refresh_token: 'old-refresh' }
+    );
+  });
+
+  it('stores new tokens after successful refresh', async () => {
+    mockGetItem.mockImplementation((key: string) =>
+      key === REFRESH_TOKEN_KEY ? Promise.resolve('old-refresh') : Promise.resolve(null)
+    );
+    mockAxiosPost.mockResolvedValue({
+      data: { access_token: 'new-access', refresh_token: 'new-refresh' },
+    });
+
+    await runResponseErrorInterceptor(make401Error()).catch(() => {});
+
+    expect(mockSetItem).toHaveBeenCalledWith(ACCESS_TOKEN_KEY, 'new-access');
+    expect(mockSetItem).toHaveBeenCalledWith(REFRESH_TOKEN_KEY, 'new-refresh');
+  });
+
+  it('clears tokens when refresh request itself fails', async () => {
+    mockGetItem.mockImplementation((key: string) =>
+      key === REFRESH_TOKEN_KEY ? Promise.resolve('old-refresh') : Promise.resolve(null)
+    );
+    mockAxiosPost.mockRejectedValue(new Error('refresh failed'));
+
+    await expect(runResponseErrorInterceptor(make401Error())).rejects.toBeDefined();
+
+    expect(mockDeleteItem).toHaveBeenCalledWith(ACCESS_TOKEN_KEY);
+    expect(mockDeleteItem).toHaveBeenCalledWith(REFRESH_TOKEN_KEY);
+  });
+});


### PR DESCRIPTION
## Summary
- LoginScreen.test.tsx (9 tests): renders, button states, promptAsync, login on success
- api.test.ts (10 tests): Bearer token injection, 401 refresh flow, token clear on failure
- test_auth_jwt.py +3: alg:none rejected, HS256 rejected, foreign RSA key rejected
- test_user_books_endpoint.py +2: PATCH/DELETE return 404 for another user's book

## Test plan
- [x] pytest tests/ → 121 passed
- [x] npx jest → 67 passed
- [x] black + ruff → clean

🤖 Generated with Claude Code