### PR TITLE
fix: pin starlette==0.52.1 to resolve Render startup timeout

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.135.1
+starlette==0.52.1
 uvicorn[standard]==0.32.1
 sqlalchemy[asyncio]==2.0.36
 alembic==1.14.1


### PR DESCRIPTION
## Summary
- Pins `starlette==0.52.1` in `backend/requirements.txt`
- `starlette` is an unpinned transitive dependency of `fastapi`; version `1.0.0` was released and auto-pulled in, causing an incompatibility with `fastapi==0.135.1`
- This caused uvicorn to crash silently at startup, triggering Render's port scan timeout after 15 minutes

## Test plan
- [ ] Verify CI passes
- [ ] Confirm Render deploy succeeds and uvicorn binds to port on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)