### PR TITLE
ci: auto-open sync PR after merges to main

### DIFF
--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -1,0 +1,10 @@
+name: Sync main → dev
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  sync:
+    uses: wcmchenry3-stack/.github/.github/workflows/called-sync-main-to-dev.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Adds `sync-main-to-dev.yml` workflow that triggers on every push to `main`
- Calls the shared reusable workflow in `wcmchenry3-stack/.github`
- Automatically opens a draft PR (`main → dev`) so branches never drift apart

🤖 Generated with [Claude Code](https://claude.com/claude-code)