### PR TITLE
security: lock CORS origins and add wildcard guard (P3-C)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,3 +1,4 @@
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -29,6 +30,13 @@ class Settings(BaseSettings):
     rate_limit_books_search: str = "30/minute"
     rate_limit_writes: str = "60/minute"
     rate_limit_reads: str = "120/minute"
+
+    @field_validator("cors_origins")
+    @classmethod
+    def no_wildcard_origins(cls, v: list[str]) -> list[str]:
+        if "*" in v:
+            raise ValueError("Wildcard '*' is not permitted in CORS_ORIGINS")
+        return v
 
     @property
     def async_database_url(self) -> str:

--- a/backend/tests/unit/test_config.py
+++ b/backend/tests/unit/test_config.py
@@ -1,5 +1,8 @@
 """Unit tests for settings config."""
 
+import pytest
+from pydantic import ValidationError
+
 from app.core.config import Settings
 
 
@@ -25,3 +28,33 @@ def test_allowed_emails_list_empty():
         allowed_emails="",
     )
     assert s.allowed_emails_list == []
+
+
+class TestCorsOriginsValidator:
+    def test_accepts_valid_origins(self):
+        s = Settings(
+            database_url="postgresql+asyncpg://u:p@localhost/db",
+            cors_origins=["https://example.onrender.com", "http://localhost:8081"],
+        )
+        assert "https://example.onrender.com" in s.cors_origins
+
+    def test_accepts_empty_origins(self):
+        s = Settings(
+            database_url="postgresql+asyncpg://u:p@localhost/db",
+            cors_origins=[],
+        )
+        assert s.cors_origins == []
+
+    def test_rejects_wildcard(self):
+        with pytest.raises(ValidationError, match="Wildcard"):
+            Settings(
+                database_url="postgresql+asyncpg://u:p@localhost/db",
+                cors_origins=["*"],
+            )
+
+    def test_rejects_wildcard_mixed_with_valid(self):
+        with pytest.raises(ValidationError, match="Wildcard"):
+            Settings(
+                database_url="postgresql+asyncpg://u:p@localhost/db",
+                cors_origins=["https://example.com", "*"],
+            )

--- a/render.yaml
+++ b/render.yaml
@@ -15,6 +15,8 @@ services:
           property: connectionString
       - key: ENVIRONMENT
         value: production
+      - key: CORS_ORIGINS
+        value: '["https://bookshelf-web-vw0s.onrender.com"]'
 
   - type: web
     name: bookshelf-web


### PR DESCRIPTION
## Summary
- `Settings.cors_origins` now rejects `*` via a `field_validator` — misconfiguration fails fast at startup rather than silently allowing all origins
- `render.yaml` now declares `CORS_ORIGINS` explicitly with the known production frontend URL (`https://bookshelf-web-vw0s.onrender.com`), moving config out of the Render dashboard and into source control
- 4 new unit tests cover valid, empty, wildcard, and mixed-wildcard cases

## Test plan
- [ ] All existing backend tests pass
- [ ] New `TestCorsOriginsValidator` tests pass (7 total in `test_config.py`)
- [ ] Setting `CORS_ORIGINS=["*"]` causes startup to raise `ValidationError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)