### PR TITLE
i18n: remove ar/he from active locales until RTL is implemented (P2-C)

### DIFF
--- a/frontend/__tests__/unit/i18n.test.ts
+++ b/frontend/__tests__/unit/i18n.test.ts
@@ -3,9 +3,9 @@
  *
  * Validates that:
  * - All 8 namespaces initialise for the `en` locale and return strings
- * - Exactly 13 locales are registered (one per entry in LOCALES)
+ * - Exactly 11 locales are registered (one per entry in LOCALES; ar/he excluded until RTL ready)
  * - No English key has __NEEDS_TRANSLATION__ as its value
- * - RTL_LOCALES contains exactly 'ar' and 'he'
+ * - RTL_LOCALES is empty (no RTL locales are currently active)
  */
 
 import i18n from '../../src/i18n/i18n';
@@ -23,10 +23,10 @@ const NAMESPACES = [
 ] as const;
 
 describe('i18n initialisation', () => {
-  it('registers exactly 13 locales', () => {
+  it('registers exactly 11 locales', () => {
     const registered = Object.keys((i18n as any).store?.data ?? {});
     expect(registered.length).toBe(LOCALES.length);
-    expect(registered.length).toBe(13);
+    expect(registered.length).toBe(11);
   });
 
   it.each(NAMESPACES)('en/%s namespace exists and has at least one string', (ns) => {
@@ -80,13 +80,11 @@ describe('i18n initialisation', () => {
 });
 
 describe('RTL_LOCALES', () => {
-  it('contains exactly ar and he', () => {
-    expect(RTL_LOCALES.size).toBe(2);
-    expect(RTL_LOCALES.has('ar')).toBe(true);
-    expect(RTL_LOCALES.has('he')).toBe(true);
+  it('is empty — ar and he are inactive until RTL layout is implemented', () => {
+    expect(RTL_LOCALES.size).toBe(0);
   });
 
-  it('does not contain ltr locales', () => {
+  it('does not contain any ltr locales', () => {
     expect(RTL_LOCALES.has('en')).toBe(false);
     expect(RTL_LOCALES.has('es')).toBe(false);
     expect(RTL_LOCALES.has('fr-CA')).toBe(false);

--- a/frontend/src/i18n/i18n.ts
+++ b/frontend/src/i18n/i18n.ts
@@ -3,7 +3,10 @@
  *
  * Metro bundler cannot resolve fully dynamic import() paths, so every
  * locale × namespace combination must be a static import.
- * 13 locales × 8 namespaces = 104 imports.
+ * 11 locales × 8 namespaces = 88 imports.
+ *
+ * ar and he are excluded until RTL layout mirroring is implemented.
+ * Translation files are preserved in locales/ar/ and locales/he/.
  */
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
@@ -59,18 +62,6 @@ import hi_wishlist from './locales/hi/wishlist.json';
 import hi_components from './locales/hi/components.json';
 
 // ---------------------------------------------------------------------------
-// ar
-// ---------------------------------------------------------------------------
-import ar_common from './locales/ar/common.json';
-import ar_auth from './locales/ar/auth.json';
-import ar_tabs from './locales/ar/tabs.json';
-import ar_myBooks from './locales/ar/my-books.json';
-import ar_scan from './locales/ar/scan.json';
-import ar_settings from './locales/ar/settings.json';
-import ar_wishlist from './locales/ar/wishlist.json';
-import ar_components from './locales/ar/components.json';
-
-// ---------------------------------------------------------------------------
 // zh
 // ---------------------------------------------------------------------------
 import zh_common from './locales/zh/common.json';
@@ -117,18 +108,6 @@ import pt_scan from './locales/pt/scan.json';
 import pt_settings from './locales/pt/settings.json';
 import pt_wishlist from './locales/pt/wishlist.json';
 import pt_components from './locales/pt/components.json';
-
-// ---------------------------------------------------------------------------
-// he
-// ---------------------------------------------------------------------------
-import he_common from './locales/he/common.json';
-import he_auth from './locales/he/auth.json';
-import he_tabs from './locales/he/tabs.json';
-import he_myBooks from './locales/he/my-books.json';
-import he_scan from './locales/he/scan.json';
-import he_settings from './locales/he/settings.json';
-import he_wishlist from './locales/he/wishlist.json';
-import he_components from './locales/he/components.json';
 
 // ---------------------------------------------------------------------------
 // de
@@ -211,16 +190,6 @@ const resources = {
     wishlist: hi_wishlist,
     components: hi_components,
   },
-  ar: {
-    common: ar_common,
-    auth: ar_auth,
-    tabs: ar_tabs,
-    'my-books': ar_myBooks,
-    scan: ar_scan,
-    settings: ar_settings,
-    wishlist: ar_wishlist,
-    components: ar_components,
-  },
   zh: {
     common: zh_common,
     auth: zh_auth,
@@ -260,16 +229,6 @@ const resources = {
     settings: pt_settings,
     wishlist: pt_wishlist,
     components: pt_components,
-  },
-  he: {
-    common: he_common,
-    auth: he_auth,
-    tabs: he_tabs,
-    'my-books': he_myBooks,
-    scan: he_scan,
-    settings: he_settings,
-    wishlist: he_wishlist,
-    components: he_components,
   },
   de: {
     common: de_common,

--- a/frontend/src/i18n/locales.ts
+++ b/frontend/src/i18n/locales.ts
@@ -3,12 +3,14 @@ export const LOCALES = [
   { code: 'fr-CA', label: 'French (Canadian)', nativeLabel: 'Français', flag: '🇨🇦', dir: 'ltr' },
   { code: 'es', label: 'Spanish', nativeLabel: 'Español', flag: '🇪🇸', dir: 'ltr' },
   { code: 'hi', label: 'Hindi', nativeLabel: 'हिन्दी', flag: '🇮🇳', dir: 'ltr' },
-  { code: 'ar', label: 'Arabic', nativeLabel: 'العربية', flag: '🇸🇦', dir: 'rtl' },
+  // ar — translations complete; re-enable once RTL layout mirroring is implemented
+  // { code: 'ar', label: 'Arabic', nativeLabel: 'العربية', flag: '🇸🇦', dir: 'rtl' },
   { code: 'zh', label: 'Chinese', nativeLabel: '中文', flag: '🇨🇳', dir: 'ltr' },
   { code: 'ja', label: 'Japanese', nativeLabel: '日本語', flag: '🇯🇵', dir: 'ltr' },
   { code: 'ko', label: 'Korean', nativeLabel: '한국어', flag: '🇰🇷', dir: 'ltr' },
   { code: 'pt', label: 'Portuguese', nativeLabel: 'Português', flag: '🇧🇷', dir: 'ltr' },
-  { code: 'he', label: 'Hebrew', nativeLabel: 'עברית', flag: '🇮🇱', dir: 'rtl' },
+  // he — translations complete; re-enable once RTL layout mirroring is implemented
+  // { code: 'he', label: 'Hebrew', nativeLabel: 'עברית', flag: '🇮🇱', dir: 'rtl' },
   { code: 'de', label: 'German', nativeLabel: 'Deutsch', flag: '🇩🇪', dir: 'ltr' },
   { code: 'nl', label: 'Dutch', nativeLabel: 'Nederlands', flag: '🇳🇱', dir: 'ltr' },
   { code: 'ru', label: 'Russian', nativeLabel: 'Русский', flag: '🇷🇺', dir: 'ltr' },


### PR DESCRIPTION
## Summary
- Arabic and Hebrew have complete translations but no RTL layout mirroring — users selecting these locales see correct text but wrong layout direction (elements still flow left-to-right)
- Shipping broken RTL is worse than not shipping it; both locales are commented out in `LOCALES` and removed from `i18n.ts` resources
- Translation files are **preserved** in `locales/ar/` and `locales/he/` — re-enabling is a one-line uncomment per locale once `I18nManager.forceRTL` and RTL style variants are implemented
- 11 active locales instead of 13

## Test plan
- [ ] All 111 frontend tests pass
- [ ] `RTL_LOCALES.size === 0`
- [ ] `LOCALES.length === 11`
- [ ] ar/he translation files still present in `src/i18n/locales/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)