### PR TITLE
feat: optimistic updates for wishlist and status transitions

### DIFF
--- a/frontend/__tests__/unit/MyBooksScreen.test.tsx
+++ b/frontend/__tests__/unit/MyBooksScreen.test.tsx
@@ -167,6 +167,46 @@ describe('MyBooksScreen', () => {
     expect(mockPatch).toHaveBeenCalledWith('/user-books/ub-1', { status: 'purchased' });
   });
 
+  it('updates status badge optimistically on "all" tab before PATCH resolves', async () => {
+    let resolvePatch!: () => void;
+    mockPatch.mockReturnValue(
+      new Promise((resolve) => {
+        resolvePatch = () => resolve({ data: {} });
+      })
+    );
+    mockGet.mockResolvedValue({ data: [WISHLISTED_BOOK] });
+    const { getByLabelText, queryByLabelText } = render(<MyBooksScreen />);
+    await waitFor(() => getByLabelText('Dune — wishlisted'));
+    fireEvent.press(getByLabelText('Dune — wishlisted'));
+    await waitFor(() => getByLabelText('Mark as Purchased'));
+
+    // Fire press and flush synchronous state updates (PATCH still pending)
+    await act(async () => {
+      fireEvent.press(getByLabelText('Mark as Purchased'));
+    });
+
+    // Card a11y label reflects the new status before API resolves
+    expect(queryByLabelText('Dune — purchased')).toBeTruthy();
+    await act(async () => {
+      resolvePatch();
+    });
+  });
+
+  it('reverts status optimistic update when PATCH fails', async () => {
+    mockPatch.mockRejectedValue(new Error('Network error'));
+    mockGet.mockResolvedValue({ data: [WISHLISTED_BOOK] });
+    const { getByLabelText, queryByText } = render(<MyBooksScreen />);
+    await waitFor(() => getByLabelText('Dune — wishlisted'));
+    fireEvent.press(getByLabelText('Dune — wishlisted'));
+    await waitFor(() => getByLabelText('Mark as Purchased'));
+
+    await act(async () => {
+      fireEvent.press(getByLabelText('Mark as Purchased'));
+    });
+
+    await waitFor(() => expect(queryByText('Wishlisted')).toBeTruthy());
+  });
+
   it('does not show advance button for read books', async () => {
     const readBook = { ...WISHLISTED_BOOK, status: 'read' };
     mockGet.mockResolvedValue({ data: [readBook] });
@@ -188,6 +228,44 @@ describe('MyBooksScreen', () => {
     });
 
     expect(mockDelete).toHaveBeenCalledWith('/user-books/ub-1');
+  });
+
+  it('removes book optimistically before DELETE resolves', async () => {
+    let resolveDelete!: () => void;
+    mockDelete.mockReturnValue(
+      new Promise((resolve) => {
+        resolveDelete = () => resolve({});
+      })
+    );
+    mockGet.mockResolvedValue({ data: [WISHLISTED_BOOK] });
+    const { getByLabelText, queryByText } = render(<MyBooksScreen />);
+    await waitFor(() => getByLabelText('Dune — wishlisted'));
+    fireEvent.press(getByLabelText('Dune — wishlisted'));
+    await waitFor(() => getByLabelText('Remove Dune'));
+
+    act(() => {
+      fireEvent.press(getByLabelText('Remove Dune'));
+    });
+
+    await waitFor(() => expect(queryByText('Dune')).toBeNull());
+    await act(async () => {
+      resolveDelete();
+    });
+  });
+
+  it('restores book when DELETE fails', async () => {
+    mockDelete.mockRejectedValue(new Error('Network error'));
+    mockGet.mockResolvedValue({ data: [WISHLISTED_BOOK] });
+    const { getByLabelText, queryByText } = render(<MyBooksScreen />);
+    await waitFor(() => getByLabelText('Dune — wishlisted'));
+    fireEvent.press(getByLabelText('Dune — wishlisted'));
+    await waitFor(() => getByLabelText('Remove Dune'));
+
+    await act(async () => {
+      fireEvent.press(getByLabelText('Remove Dune'));
+    });
+
+    await waitFor(() => expect(queryByText('Dune')).toBeTruthy());
   });
 
   it('refetches when a filter tab is tapped', async () => {

--- a/frontend/__tests__/unit/WishlistScreen.test.tsx
+++ b/frontend/__tests__/unit/WishlistScreen.test.tsx
@@ -106,6 +106,41 @@ describe('WishlistScreen', () => {
     await waitFor(() => expect(queryByText('Dune')).toBeNull());
   });
 
+  it('removes book optimistically before PATCH resolves', async () => {
+    let resolvePatch!: () => void;
+    mockPatch.mockReturnValue(
+      new Promise((resolve) => {
+        resolvePatch = () => resolve({ data: {} });
+      })
+    );
+    mockGet.mockResolvedValue({ data: [BOOK_1] });
+    const { getByLabelText, queryByText } = render(<WishlistScreen />);
+    await waitFor(() => getByLabelText('Mark Dune as purchased'));
+
+    act(() => {
+      fireEvent.press(getByLabelText('Mark Dune as purchased'));
+    });
+
+    // Item gone before PATCH resolves
+    expect(queryByText('Dune')).toBeNull();
+    await act(async () => {
+      resolvePatch();
+    });
+  });
+
+  it('restores book when PATCH fails', async () => {
+    mockPatch.mockRejectedValue(new Error('Network error'));
+    mockGet.mockResolvedValue({ data: [BOOK_1] });
+    const { getByLabelText, queryByText } = render(<WishlistScreen />);
+    await waitFor(() => getByLabelText('Mark Dune as purchased'));
+
+    await act(async () => {
+      fireEvent.press(getByLabelText('Mark Dune as purchased'));
+    });
+
+    await waitFor(() => expect(queryByText('Dune')).toBeTruthy());
+  });
+
   it('calls DELETE and removes book when Remove pressed', async () => {
     mockGet.mockResolvedValue({ data: [BOOK_1] });
     const { getByLabelText, queryByText } = render(<WishlistScreen />);
@@ -117,6 +152,40 @@ describe('WishlistScreen', () => {
 
     expect(mockDelete).toHaveBeenCalledWith('/user-books/ub-1');
     await waitFor(() => expect(queryByText('Dune')).toBeNull());
+  });
+
+  it('removes book optimistically before DELETE resolves', async () => {
+    let resolveDelete!: () => void;
+    mockDelete.mockReturnValue(
+      new Promise((resolve) => {
+        resolveDelete = () => resolve({});
+      })
+    );
+    mockGet.mockResolvedValue({ data: [BOOK_1] });
+    const { getByLabelText, queryByText } = render(<WishlistScreen />);
+    await waitFor(() => getByLabelText('Remove Dune from wishlist'));
+
+    act(() => {
+      fireEvent.press(getByLabelText('Remove Dune from wishlist'));
+    });
+
+    expect(queryByText('Dune')).toBeNull();
+    await act(async () => {
+      resolveDelete();
+    });
+  });
+
+  it('restores book when DELETE fails', async () => {
+    mockDelete.mockRejectedValue(new Error('Network error'));
+    mockGet.mockResolvedValue({ data: [BOOK_1] });
+    const { getByLabelText, queryByText } = render(<WishlistScreen />);
+    await waitFor(() => getByLabelText('Remove Dune from wishlist'));
+
+    await act(async () => {
+      fireEvent.press(getByLabelText('Remove Dune from wishlist'));
+    });
+
+    await waitFor(() => expect(queryByText('Dune')).toBeTruthy());
   });
 
   it('fetches with status=wishlisted filter', async () => {

--- a/frontend/app/(tabs)/my-books.tsx
+++ b/frontend/app/(tabs)/my-books.tsx
@@ -89,21 +89,32 @@ export default function MyBooksScreen() {
   async function handleAdvanceStatus(item: UserBook) {
     const next = NEXT_STATUS[item.status];
     if (!next) return;
+    // Optimistic: on "all" tab update status in-place; on filtered tabs remove the item
+    setBooks((prev) =>
+      activeTab === 'all'
+        ? prev.map((b) => (b.id === item.id ? { ...b, status: next } : b))
+        : prev.filter((b) => b.id !== item.id)
+    );
+    setSelected(null);
     try {
       await api.patch(`/user-books/${item.id}`, { status: next });
-      setSelected(null);
-      fetchBooks();
     } catch {
+      setBooks((prev) =>
+        activeTab === 'all'
+          ? prev.map((b) => (b.id === item.id ? { ...b, status: item.status } : b))
+          : [...prev, item]
+      );
       Alert.alert(t('errorTitle', { ns: 'common' }), t('errorUpdateStatus'));
     }
   }
 
   async function handleRemove(item: UserBook) {
+    setBooks((prev) => prev.filter((b) => b.id !== item.id));
+    setSelected(null);
     try {
       await api.delete(`/user-books/${item.id}`);
-      setSelected(null);
-      setBooks((prev) => prev.filter((b) => b.id !== item.id));
     } catch {
+      setBooks((prev) => [...prev, item]);
       Alert.alert(t('errorTitle', { ns: 'common' }), t('errorRemoveBook'));
     }
   }

--- a/frontend/app/(tabs)/wishlist.tsx
+++ b/frontend/app/(tabs)/wishlist.tsx
@@ -59,19 +59,21 @@ export default function WishlistScreen() {
   );
 
   async function handleMarkPurchased(item: UserBook) {
+    setBooks((prev) => prev.filter((b) => b.id !== item.id));
     try {
       await api.patch(`/user-books/${item.id}`, { status: 'purchased' });
-      setBooks((prev) => prev.filter((b) => b.id !== item.id));
     } catch {
+      setBooks((prev) => [...prev, item]);
       Alert.alert(t('errorTitle', { ns: 'common' }), t('errorUpdateStatus'));
     }
   }
 
   async function handleRemove(item: UserBook) {
+    setBooks((prev) => prev.filter((b) => b.id !== item.id));
     try {
       await api.delete(`/user-books/${item.id}`);
-      setBooks((prev) => prev.filter((b) => b.id !== item.id));
     } catch {
+      setBooks((prev) => [...prev, item]);
       Alert.alert(t('errorTitle', { ns: 'common' }), t('errorRemoveBook'));
     }
   }


### PR DESCRIPTION
## Summary
- Wishlist: mark-purchased and remove apply changes immediately; restore book if the API call fails
- My Books: advance-status updates the badge in-place on the \"All\" tab and removes the item on filtered tabs, all before the API resolves; remove also applies optimistically
- 8 new tests covering the revert-on-failure paths for both screens

## Test plan
- [ ] All 123 existing + new tests pass (`npx jest`)
- [ ] 86.66% line coverage (above 80% gate)
- [ ] Tap \"Mark Purchased\" on wishlist — item disappears instantly, no spinner
- [ ] Disable network, tap action — item restores after error alert
- [ ] Open book in My Books, advance status — badge updates and modal closes immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)