### PR TITLE
refactor: structured JSON logging, request IDs, remove dead ABC

### DIFF
--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -1,0 +1,34 @@
+"""Structured JSON logging and per-request ID propagation."""
+
+import json
+import logging
+import uuid
+from contextvars import ContextVar
+
+request_id_var: ContextVar[str] = ContextVar("request_id", default="-")
+
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        log_obj: dict = {
+            "time": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "logger": record.name,
+            "request_id": request_id_var.get(),
+            "message": record.getMessage(),
+        }
+        if record.exc_info:
+            log_obj["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(log_obj)
+
+
+def configure_logging() -> None:
+    handler = logging.StreamHandler()
+    handler.setFormatter(JsonFormatter())
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    root.handlers = [handler]
+
+
+def new_request_id() -> str:
+    return str(uuid.uuid4())

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,10 +16,20 @@ from app.api.user_books import router as user_books_router
 from app.core.config import settings
 from app.core.database import AsyncSessionLocal
 from app.core.limiter import limiter
+from app.core.logging import configure_logging, new_request_id, request_id_var
 
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s"
-)
+configure_logging()
+
+logger = logging.getLogger(__name__)
+
+
+class RequestIdMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next) -> Response:
+        rid = new_request_id()
+        request_id_var.set(rid)
+        response = await call_next(request)
+        response.headers["X-Request-ID"] = rid
+        return response
 
 
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):
@@ -42,6 +52,7 @@ app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
 app.add_middleware(SecurityHeadersMiddleware)
+app.add_middleware(RequestIdMiddleware)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.cors_origins,

--- a/backend/app/services/book_identifier.py
+++ b/backend/app/services/book_identifier.py
@@ -1,6 +1,5 @@
-"""Abstract interface for book identification from images."""
+"""Shared types for book identification."""
 
-from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
 
@@ -15,9 +14,3 @@ class BookCandidate:
 
 class ScanUnavailableError(Exception):
     """Raised when the vision API is unreachable or times out."""
-
-
-class BookIdentifierService(ABC):
-    @abstractmethod
-    async def identify(self, image_bytes: bytes) -> list[BookCandidate]:
-        """Identify books from a cover image. Returns up to 3 candidates ranked by confidence."""

--- a/backend/app/services/chatgpt_vision.py
+++ b/backend/app/services/chatgpt_vision.py
@@ -7,11 +7,7 @@ import logging
 import httpx
 
 from app.core.config import settings
-from app.services.book_identifier import (
-    BookCandidate,
-    BookIdentifierService,
-    ScanUnavailableError,
-)
+from app.services.book_identifier import BookCandidate, ScanUnavailableError
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +27,7 @@ Return ONLY a valid JSON array, no other text. Example:
 [{"title":"Dune","author":"Frank Herbert","confidence":0.97,"isbn_13":"9780441013593","isbn_10":null}]"""
 
 
-class ChatGPTVisionIdentifier(BookIdentifierService):
+class ChatGPTVisionIdentifier:
     async def identify(self, image_bytes: bytes) -> list[BookCandidate]:
         b64 = base64.standard_b64encode(image_bytes).decode()
 

--- a/backend/tests/unit/test_logging.py
+++ b/backend/tests/unit/test_logging.py
@@ -1,0 +1,143 @@
+"""Tests for structured JSON logging and request ID middleware."""
+
+import json
+import logging
+from unittest.mock import AsyncMock, patch
+
+from starlette.testclient import TestClient
+
+from app.core.logging import JsonFormatter, request_id_var
+
+
+class TestJsonFormatter:
+    def _make_record(self, msg: str, level: int = logging.INFO) -> logging.LogRecord:
+        return logging.LogRecord(
+            name="test.logger",
+            level=level,
+            pathname="",
+            lineno=0,
+            msg=msg,
+            args=(),
+            exc_info=None,
+        )
+
+    def test_output_is_valid_json(self):
+        record = self._make_record("hello")
+        line = JsonFormatter().format(record)
+        parsed = json.loads(line)
+        assert isinstance(parsed, dict)
+
+    def test_required_keys_present(self):
+        record = self._make_record("hello")
+        parsed = json.loads(JsonFormatter().format(record))
+        assert "time" in parsed
+        assert "level" in parsed
+        assert "logger" in parsed
+        assert "message" in parsed
+        assert "request_id" in parsed
+
+    def test_message_matches(self):
+        record = self._make_record("test message")
+        parsed = json.loads(JsonFormatter().format(record))
+        assert parsed["message"] == "test message"
+
+    def test_level_matches(self):
+        record = self._make_record("warn", logging.WARNING)
+        parsed = json.loads(JsonFormatter().format(record))
+        assert parsed["level"] == "WARNING"
+
+    def test_logger_name_matches(self):
+        record = self._make_record("hi")
+        parsed = json.loads(JsonFormatter().format(record))
+        assert parsed["logger"] == "test.logger"
+
+    def test_request_id_from_context_var(self):
+        token = request_id_var.set("test-request-id-123")
+        try:
+            record = self._make_record("hi")
+            parsed = json.loads(JsonFormatter().format(record))
+            assert parsed["request_id"] == "test-request-id-123"
+        finally:
+            request_id_var.reset(token)
+
+    def test_default_request_id_is_dash_when_not_set(self):
+        # Reset to default
+        token = request_id_var.set("-")
+        try:
+            record = self._make_record("hi")
+            parsed = json.loads(JsonFormatter().format(record))
+            assert parsed["request_id"] == "-"
+        finally:
+            request_id_var.reset(token)
+
+    def test_exc_info_included_when_present(self):
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            import sys
+
+            exc_info = sys.exc_info()
+
+        record = logging.LogRecord(
+            name="test",
+            level=logging.ERROR,
+            pathname="",
+            lineno=0,
+            msg="error",
+            args=(),
+            exc_info=exc_info,
+        )
+        parsed = json.loads(JsonFormatter().format(record))
+        assert "exc_info" in parsed
+        assert "ValueError" in parsed["exc_info"]
+
+
+class TestRequestIdMiddleware:
+    def test_x_request_id_header_present_in_response(self):
+        from app.main import app
+
+        with patch("app.main.AsyncSessionLocal") as mock_session_cls:
+            mock_session = AsyncMock()
+            mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session.__aexit__ = AsyncMock(return_value=False)
+            mock_session.execute = AsyncMock()
+            mock_session_cls.return_value = mock_session
+
+            client = TestClient(app, raise_server_exceptions=False)
+            resp = client.get("/health")
+
+        assert "x-request-id" in resp.headers
+
+    def test_x_request_id_is_a_valid_uuid(self):
+        import uuid
+
+        from app.main import app
+
+        with patch("app.main.AsyncSessionLocal") as mock_session_cls:
+            mock_session = AsyncMock()
+            mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session.__aexit__ = AsyncMock(return_value=False)
+            mock_session.execute = AsyncMock()
+            mock_session_cls.return_value = mock_session
+
+            client = TestClient(app, raise_server_exceptions=False)
+            resp = client.get("/health")
+
+        rid = resp.headers["x-request-id"]
+        uuid.UUID(rid)  # raises if not valid UUID
+
+    def test_each_request_gets_a_unique_id(self):
+        from app.main import app
+
+        with patch("app.main.AsyncSessionLocal") as mock_session_cls:
+            mock_session = AsyncMock()
+            mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session.__aexit__ = AsyncMock(return_value=False)
+            mock_session.execute = AsyncMock()
+            mock_session_cls.return_value = mock_session
+
+            client = TestClient(app, raise_server_exceptions=False)
+            r1 = client.get("/health")
+            r2 = client.get("/health")
+
+        assert r1.headers["x-request-id"] != r2.headers["x-request-id"]


### PR DESCRIPTION
## Summary
- **P3-B** — `app/core/logging.py` adds a `JsonFormatter` (every log line is a JSON object with `time`, `level`, `logger`, `request_id`, `message`) and a `request_id_var` ContextVar. `RequestIdMiddleware` generates a UUID per request, injects it into the context so all service logs carry it, and returns it as `X-Request-ID`. Replaces `logging.basicConfig`.
- **P3-D** — Removed the `BookIdentifierService` abstract base class (one implementation, zero substitution value). `book_identifier.py` keeps `BookCandidate` and `ScanUnavailableError` as shared types. `ChatGPTVisionIdentifier` becomes a plain class.

## Test plan
- [ ] 11 new unit tests: `JsonFormatter` output shape, context-var propagation, exc_info inclusion; middleware header presence, UUID validity, uniqueness per request
- [ ] Full backend suite: 170 passed, 0 failures
- [ ] black + ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)