### PR TITLE
fix: use webClientId for Google auth on web

### DIFF
--- a/frontend/app/(auth)/login.tsx
+++ b/frontend/app/(auth)/login.tsx
@@ -15,7 +15,7 @@ export default function LoginScreen() {
   const { t } = useTranslation('auth');
 
   const [request, response, promptAsync] = Google.useIdTokenAuthRequest({
-    clientId: process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID,
+    webClientId: process.env.EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID,
     iosClientId: process.env.EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID,
     androidClientId: process.env.EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID,
   });


### PR DESCRIPTION
## Summary
- `expo-auth-session` v5 requires `webClientId` explicitly on the web platform. The old `clientId` prop is only used as a fallback when the env var is defined — when it's undefined at bundle time (Render build), the invariant throws and crashes the app.
- Renames the env var `EXPO_PUBLIC_GOOGLE_CLIENT_ID` → `EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID` to match the prop name.

## Action required after merge
In Render → **bookshelf-web** static site → **Environment**, add a build-time env var:
```
EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID = <your Google web OAuth client ID>
```
`EXPO_PUBLIC_*` vars are baked into the bundle at `expo export` time, so they must be set in the build environment, not runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)