### PR TITLE
fix: declare EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID in render.yaml for web …

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -56,6 +56,8 @@ services:
     envVars:
       - key: EXPO_PUBLIC_API_URL
         value: https://bookshelf-api-rxp3.onrender.com
+      - key: EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID
+        sync: false
 
 databases:
   - name: bookshelf-db


### PR DESCRIPTION
…build

Uses sync:false so the value is set in the Render dashboard rather than hardcoded in source, fixing the missing webClientId crash on the web platform.

## Summary
<!-- What does this PR do? Focus on the why, not the how. -->
-

## Type of change
- [ ] `feat` — new feature or behaviour
- [ ] `fix` — bug fix
- [ ] `chore` — tooling, deps, config
- [ ] `test` — adding or updating tests
- [ ] `docs` — documentation only
- [ ] `refactor` — code change that is neither fix nor feature
- [ ] `ci` — CI/CD changes
- [ ] `a11y` — accessibility improvement
- [ ] `security` — security hardening

## Testing done
<!-- What did you run? Any coverage delta? -->
- [ ] All tests pass locally
- [ ] No new lint errors

## Security checklist
- [ ] No secrets committed (gitleaks passes)
- [ ] Dependencies reviewed if new ones added
- [ ] OWASP considerations addressed if auth or data handling was touched

## Accessibility checklist *(frontend PRs only)*
- [ ] axe DevTools — no violations on affected pages
- [ ] Keyboard navigation tested
- [ ] Tested at 320px viewport width
- [ ] Tested at 200% zoom
