### PR TITLE
feat: add OpenAI policy workflow call to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,3 +96,7 @@ jobs:
         env:
           DATABASE_URL: postgresql://test:test@localhost:5432/test
         run: alembic downgrade -1
+
+  openai-policy:
+    uses: wcmchenry3-stack/.github/.github/workflows/called-openai-policy.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Adds the `openai-policy` job to CI, calling the shared `called-openai-policy.yml` reusable workflow
- Checks run only when changed files reference the OpenAI API — skips cleanly otherwise
- Enforces: no hardcoded API keys, rate-limit handling, model version pinning (warning), token limits

## Test plan
- [ ] Open a PR that does not touch OpenAI code — confirm policy checks are skipped
- [ ] Open a PR that touches OpenAI code — confirm all 4 checks run

🤖 Generated with [Claude Code](https://claude.com/claude-code)