### PR TITLE
fix: clear Metro cache on expo export to force fresh env var inlining

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -23,7 +23,7 @@ services:
     name: bookshelf-web
     env: static
     region: oregon
-    buildCommand: npm ci && npx expo export --platform web
+    buildCommand: npm ci && npx expo export --platform web --clear
     staticPublishPath: dist
     rootDir: frontend
     pullRequestPreviewsEnabled: false


### PR DESCRIPTION
Without --clear, Metro reuses cached transforms and EXPO_PUBLIC_* env vars are not re-evaluated, so the bundle hash never changes between deploys.

## Summary
<!-- What does this PR do? Focus on the why, not the how. -->
-

## Type of change
- [ ] `feat` — new feature or behaviour
- [ ] `fix` — bug fix
- [ ] `chore` — tooling, deps, config
- [ ] `test` — adding or updating tests
- [ ] `docs` — documentation only
- [ ] `refactor` — code change that is neither fix nor feature
- [ ] `ci` — CI/CD changes
- [ ] `a11y` — accessibility improvement
- [ ] `security` — security hardening

## Testing done
<!-- What did you run? Any coverage delta? -->
- [ ] All tests pass locally
- [ ] No new lint errors

## Security checklist
- [ ] No secrets committed (gitleaks passes)
- [ ] Dependencies reviewed if new ones added
- [ ] OWASP considerations addressed if auth or data handling was touched

## Accessibility checklist *(frontend PRs only)*
- [ ] axe DevTools — no violations on affected pages
- [ ] Keyboard navigation tested
- [ ] Tested at 320px viewport width
- [ ] Tested at 200% zoom
