### PR TITLE
fix: remove duplicate openai-policy job causing CI startup failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,3 @@ jobs:
           DATABASE_URL: postgresql://test:test@localhost:5432/test
         run: alembic downgrade -1
 
-  openai-policy:
-    uses: wcmchenry3-stack/.github/.github/workflows/called-openai-policy.yml@main
-    secrets: inherit


### PR DESCRIPTION
## Summary
- Merging `fix/google-auth-web` into `dev` created a duplicate `openai-policy` job because `dev` already had one (without `allowed-repos`)
- Duplicate job names cause GitHub Actions startup failures before any checks run
- Removes the old duplicate (the one without `allowed-repos`); keeps the correct version with `allowed-repos: wcmchenry3-stack/book_app`

## Test plan
- [ ] Confirm CI starts successfully on this PR (no startup_failure)
- [ ] All jobs run and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)