### PR TITLE
fix: restore allowed-repos on openai-policy + render.yaml fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
 
   openai-policy:
     uses: wcmchenry3-stack/.github/.github/workflows/called-openai-policy.yml@main
+    with:
+      allowed-repos: wcmchenry3-stack/book_app
     secrets: inherit
 
   secret-scan:


### PR DESCRIPTION
## Summary
- Restores `allowed-repos: wcmchenry3-stack/book_app` on the `openai-policy` job — removed by PR #70, causing CI startup failures again
- Includes `render.yaml` fixes for Google auth web: `--clear` flag and `EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID` env var declaration

🤖 Generated with [Claude Code](https://claude.com/claude-code)