### PR TITLE
fix: remove allowed-repos from openai-policy job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ jobs:
 
   openai-policy:
     uses: wcmchenry3-stack/.github/.github/workflows/called-openai-policy.yml@main
-    with:
-      allowed-repos: wcmchenry3-stack/book_app
     secrets: inherit
 
   secret-scan:


### PR DESCRIPTION
## Summary
- Removes `allowed-repos` from the `openai-policy` job — it breaks CI and was incorrectly re-added in PR #71
- Keeps the `render.yaml` improvements from PR #71 (`--clear` flag, `EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID` declaration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)