### PR TITLE
fix: write Google web client ID to .env before expo export

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -23,7 +23,7 @@ services:
     name: bookshelf-web
     env: static
     region: oregon
-    buildCommand: npm ci && npx expo export --platform web --clear
+    buildCommand: npm ci && printf "EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=%s\n" "$EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID" > .env && npx expo export --platform web --clear
     staticPublishPath: dist
     rootDir: frontend
     pullRequestPreviewsEnabled: false


### PR DESCRIPTION
## Summary
- Writes `EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID` to a `.env` file before running `expo export`
- Expo reads `EXPO_PUBLIC_*` vars from `.env` files explicitly; passing them as system env vars via Render has not reliably reached the Metro bundler
- This guarantees the value is baked into the bundle, changing the entry bundle hash and resolving the "webClientId must be defined" crash

## Test plan
- [ ] After merge → main → Render deploy, the entry bundle hash should be different from `entry-27b59eeb8c127ac5f289299ff6b8b603.js`
- [ ] Site loads without the webClientId error

🤖 Generated with [Claude Code](https://claude.com/claude-code)