### PR TITLE
fix: bake API URL into bundle and allow OAuth popup communication

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -23,7 +23,7 @@ services:
     name: bookshelf-web
     env: static
     region: oregon
-    buildCommand: npm ci && printf "EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=%s\n" "$EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID" > .env && npx expo export --platform web --clear
+    buildCommand: npm ci && printf "EXPO_PUBLIC_API_URL=%s\nEXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=%s\n" "$EXPO_PUBLIC_API_URL" "$EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID" > .env && npx expo export --platform web --clear
     staticPublishPath: dist
     rootDir: frontend
     pullRequestPreviewsEnabled: false
@@ -32,6 +32,9 @@ services:
         source: /*
         destination: /index.html
     headers:
+      - path: /*
+        name: Cross-Origin-Opener-Policy
+        value: unsafe-none
       - path: /*
         name: X-Frame-Options
         value: DENY


### PR DESCRIPTION
## Summary
- Writes both `EXPO_PUBLIC_API_URL` and `EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID` to `.env` before `expo export` — previously only the Google client ID was written, so API calls fell back to `localhost:8000`
- Adds `Cross-Origin-Opener-Policy: unsafe-none` header so the Google OAuth popup can `postMessage` the id_token back to the opener window

## Test plan
- [ ] After deploy, Google SSO popup completes and redirects to the app
- [ ] API call goes to `bookshelf-api-rxp3.onrender.com`, not localhost

🤖 Generated with [Claude Code](https://claude.com/claude-code)