### PR TITLE
fix: redirect to /(tabs)/my-books after login

### DIFF
--- a/frontend/contexts/AuthContext.tsx
+++ b/frontend/contexts/AuthContext.tsx
@@ -39,7 +39,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     if (!isAuthenticated && !inAuthGroup) {
       router.replace('/(auth)/login');
     } else if (isAuthenticated && inAuthGroup) {
-      router.replace('/(tabs)');
+      router.replace('/(tabs)/my-books');
     }
   }, [isAuthenticated, isLoading, segments, router]);
 


### PR DESCRIPTION
## Summary
- `/(tabs)` has no `index.tsx`, so `router.replace('/(tabs)')` after login produces a 404
- Changed to `router.replace('/(tabs)/my-books')` to land on a valid route

🤖 Generated with [Claude Code](https://claude.com/claude-code)