### PR TITLE
fix: add root index.tsx to resolve unmatched route on /

### DIFF
--- a/frontend/app/index.tsx
+++ b/frontend/app/index.tsx
@@ -1,0 +1,22 @@
+import { ActivityIndicator, View } from 'react-native';
+import { Redirect } from 'expo-router';
+
+import { useAuth } from '../hooks/useAuth';
+
+export default function Index() {
+  const { isAuthenticated, isLoading } = useAuth();
+
+  if (isLoading) {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <ActivityIndicator />
+      </View>
+    );
+  }
+
+  if (isAuthenticated) {
+    return <Redirect href="/(tabs)/my-books" />;
+  }
+
+  return <Redirect href="/(auth)/login" />;
+}


### PR DESCRIPTION
## Summary
- Without `app/index.tsx`, navigating to `/` shows Expo Router's unmatched route screen while auth state loads
- New index shows a spinner while loading, then redirects to `/(tabs)/my-books` if authenticated or `/(auth)/login` if not

🤖 Generated with [Claude Code](https://claude.com/claude-code)