### PR TITLE
fix: resolve camera scan issues on iOS Chrome

### DIFF
--- a/frontend/__tests__/unit/ScanScreen.test.tsx
+++ b/frontend/__tests__/unit/ScanScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Alert } from 'react-native';
+import { Alert, Platform } from 'react-native';
 import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 
 import ScanScreen from '../../app/(tabs)/scan';
@@ -14,11 +14,23 @@ jest.mock('../../lib/api', () => ({
   },
 }));
 
+const mockTakePictureAsync = jest.fn();
 const mockRequestPermission = jest.fn();
-jest.mock('expo-camera', () => ({
-  CameraView: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  useCameraPermissions: jest.fn(),
-}));
+
+jest.mock('expo-camera', () => {
+  const React = require('react');
+  const MockCameraView = React.forwardRef(
+    ({ children }: { children: React.ReactNode }, ref: React.Ref<unknown>) => {
+      React.useImperativeHandle(ref, () => ({ takePictureAsync: mockTakePictureAsync }));
+      return <>{children}</>;
+    }
+  );
+  MockCameraView.displayName = 'CameraView';
+  return {
+    CameraView: MockCameraView,
+    useCameraPermissions: jest.fn(),
+  };
+});
 
 jest.mock('../../hooks/useTheme', () => ({
   useTheme: () => ({
@@ -97,6 +109,9 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
+// ---------------------------------------------------------------------------
+// Search mode
+// ---------------------------------------------------------------------------
 describe('ScanScreen — search mode', () => {
   function renderInSearchMode() {
     const utils = render(<ScanScreen />);
@@ -121,7 +136,6 @@ describe('ScanScreen — search mode', () => {
     fireEvent.changeText(getByLabelText('Book title or author search'), 'Dune');
     fireEvent.press(getByLabelText('Search for book'));
     expect(getByTestId('loading-spinner')).toBeTruthy();
-    // Clean up: resolve so no pending state update leaks
     await act(async () => resolveGet({ data: [] }));
   });
 
@@ -166,10 +180,18 @@ describe('ScanScreen — search mode', () => {
   });
 });
 
-describe('ScanScreen — camera mode', () => {
+// ---------------------------------------------------------------------------
+// Camera mode — permissions
+// ---------------------------------------------------------------------------
+describe('ScanScreen — camera mode permissions', () => {
   it('renders capture button by default when permission is granted', () => {
     const { getByLabelText } = render(<ScanScreen />);
     expect(getByLabelText('Capture book cover')).toBeTruthy();
+  });
+
+  it('renders flip camera button when permission is granted', () => {
+    const { getByLabelText } = render(<ScanScreen />);
+    expect(getByLabelText('Flip camera')).toBeTruthy();
   });
 
   it('shows permission prompt when camera permission is not granted', () => {
@@ -192,6 +214,113 @@ describe('ScanScreen — camera mode', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Camera mode — facing toggle
+// ---------------------------------------------------------------------------
+describe('ScanScreen — camera facing toggle', () => {
+  it('shows flip button overlay in camera mode', () => {
+    const { getByLabelText } = render(<ScanScreen />);
+    expect(getByLabelText('Flip camera')).toBeTruthy();
+  });
+
+  it('toggles facing state when flip button is pressed', () => {
+    const { getByLabelText } = render(<ScanScreen />);
+    const flipBtn = getByLabelText('Flip camera');
+    // Press once: back → front
+    fireEvent.press(flipBtn);
+    // Press again: front → back — button still present
+    fireEvent.press(flipBtn);
+    expect(getByLabelText('Flip camera')).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Camera mode — capture flow
+// ---------------------------------------------------------------------------
+describe('ScanScreen — capture flow', () => {
+  it('shows loading spinner during capture', async () => {
+    let resolveTake!: (v: unknown) => void;
+    mockTakePictureAsync.mockReturnValue(
+      new Promise((res) => {
+        resolveTake = res;
+      })
+    );
+    const { getByLabelText, getByTestId } = render(<ScanScreen />);
+    fireEvent.press(getByLabelText('Capture book cover'));
+    expect(getByTestId('loading-spinner')).toBeTruthy();
+    await act(async () => resolveTake({ uri: 'file://test.jpg' }));
+  });
+
+  it('shows picker after successful scan', async () => {
+    mockTakePictureAsync.mockResolvedValue({ uri: 'file://test.jpg' });
+    mockPost.mockResolvedValue({ data: [{ title: 'Dune', author: 'Herbert' }] });
+
+    const { getByLabelText, getByTestId } = render(<ScanScreen />);
+    await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
+    await waitFor(() => expect(getByTestId('dismiss-picker')).toBeTruthy());
+    expect(mockPost).toHaveBeenCalledWith('/scan', expect.any(FormData), expect.any(Object));
+  });
+
+  it('alerts when scan returns no books', async () => {
+    mockTakePictureAsync.mockResolvedValue({ uri: 'file://test.jpg' });
+    mockPost.mockResolvedValue({ data: [] });
+
+    const { getByLabelText } = render(<ScanScreen />);
+    await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
+    expect(Alert.alert).toHaveBeenCalledWith('No books found', expect.any(String));
+  });
+
+  it('alerts with scan-unavailable message on 503', async () => {
+    mockTakePictureAsync.mockResolvedValue({ uri: 'file://test.jpg' });
+    mockPost.mockRejectedValue(makeAxiosError(503));
+
+    const { getByLabelText } = render(<ScanScreen />);
+    await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
+    expect(Alert.alert).toHaveBeenCalledWith('Scan unavailable', expect.any(String));
+  });
+
+  it('alerts with generic scan-failed message on other errors', async () => {
+    mockTakePictureAsync.mockResolvedValue({ uri: 'file://test.jpg' });
+    mockPost.mockRejectedValue(new Error('network'));
+
+    const { getByLabelText } = render(<ScanScreen />);
+    await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
+    expect(Alert.alert).toHaveBeenCalledWith('Scan failed', expect.any(String));
+  });
+
+  it('exits early without alert when takePictureAsync returns no uri', async () => {
+    mockTakePictureAsync.mockResolvedValue({ uri: null });
+
+    const { getByLabelText } = render(<ScanScreen />);
+    await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
+    expect(mockPost).not.toHaveBeenCalled();
+    expect(Alert.alert).not.toHaveBeenCalled();
+  });
+
+  it('uses fetch blob path on web platform', async () => {
+    const originalOS = Platform.OS;
+    Object.defineProperty(Platform, 'OS', { value: 'web', configurable: true });
+
+    const mockBlob = new Blob(['img'], { type: 'image/jpeg' });
+    const mockFetch = jest.fn().mockResolvedValue({ blob: () => Promise.resolve(mockBlob) });
+    (global as unknown as { fetch: typeof mockFetch }).fetch = mockFetch;
+
+    mockTakePictureAsync.mockResolvedValue({ uri: 'data:image/jpeg;base64,abc' });
+    mockPost.mockResolvedValue({ data: [{ title: 'Test Book' }] });
+
+    const { getByLabelText, getByTestId } = render(<ScanScreen />);
+    await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
+    await waitFor(() => expect(getByTestId('dismiss-picker')).toBeTruthy());
+
+    expect(mockFetch).toHaveBeenCalledWith('data:image/jpeg;base64,abc');
+
+    Object.defineProperty(Platform, 'OS', { value: originalOS, configurable: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Select book
+// ---------------------------------------------------------------------------
 describe('ScanScreen — select book', () => {
   it('posts to wishlist and alerts on success', async () => {
     mockGet.mockResolvedValue({ data: [{ title: 'Dune', author: 'Herbert' }] });
@@ -215,25 +344,6 @@ describe('ScanScreen — select book', () => {
     await act(async () => fireEvent.press(getByLabelText('Search for book')));
     await waitFor(() => expect(getByTestId('select-book-0')).toBeTruthy());
     await act(async () => fireEvent.press(getByTestId('select-book-0')));
-    expect(Alert.alert).toHaveBeenCalled();
-  });
-});
-
-describe('ScanScreen — scan unavailable (503)', () => {
-  it('alerts with scan unavailable message on 503 during capture', async () => {
-    // cameraRef.current is null in tests so handleCapture exits early;
-    // verify the 503 alert branch via the axios error check directly
-    const axiosError = makeAxiosError(503);
-    mockPost.mockRejectedValue(axiosError);
-    mockGet.mockResolvedValue({ data: [{ title: 'Dune', author: 'Herbert' }] });
-
-    const { getByLabelText, getByTestId } = render(<ScanScreen />);
-    fireEvent.press(getByLabelText('Text search mode'));
-    fireEvent.changeText(getByLabelText('Book title or author search'), 'Dune');
-    await act(async () => fireEvent.press(getByLabelText('Search for book')));
-    await waitFor(() => expect(getByTestId('select-book-0')).toBeTruthy());
-    await act(async () => fireEvent.press(getByTestId('select-book-0')));
-    // post to /wishlist fails — generic alert, not 503 (503 is for scan endpoint)
     expect(Alert.alert).toHaveBeenCalled();
   });
 });

--- a/frontend/app/(tabs)/scan.tsx
+++ b/frontend/app/(tabs)/scan.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from 'react';
-import { Alert, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+import { Alert, Platform, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
 import { CameraView, useCameraPermissions } from 'expo-camera';
 import { isAxiosError } from 'axios';
 import { useTranslation } from 'react-i18next';
@@ -11,6 +11,7 @@ import { api } from '../../lib/api';
 
 type InputMode = 'camera' | 'search';
 type ScreenState = 'idle' | 'loading' | 'picker';
+type CameraFacing = 'back' | 'front';
 
 export default function ScanScreen() {
   const { theme } = useTheme();
@@ -20,6 +21,7 @@ export default function ScanScreen() {
   const [screenState, setScreenState] = useState<ScreenState>('idle');
   const [candidates, setCandidates] = useState<EnrichedBook[]>([]);
   const [query, setQuery] = useState('');
+  const [facing, setFacing] = useState<CameraFacing>('back');
   const cameraRef = useRef<CameraView>(null);
 
   async function handleCapture() {
@@ -38,11 +40,16 @@ export default function ScanScreen() {
       }
 
       const formData = new FormData();
-      formData.append('file', {
-        uri: photo.uri,
-        name: 'scan.jpg',
-        type: 'image/jpeg',
-      } as unknown as Blob);
+      if (Platform.OS === 'web') {
+        const blob = await fetch(photo.uri).then((r) => r.blob());
+        formData.append('file', blob, 'scan.jpg');
+      } else {
+        formData.append('file', {
+          uri: photo.uri,
+          name: 'scan.jpg',
+          type: 'image/jpeg',
+        } as unknown as Blob);
+      }
 
       const response = await api.post<EnrichedBook[]>('/scan', formData, {
         headers: { 'Content-Type': 'multipart/form-data' },
@@ -106,14 +113,6 @@ export default function ScanScreen() {
     setScreenState('idle');
   }
 
-  if (screenState === 'loading') {
-    return (
-      <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
-        <LoadingSpinner message={t('loading')} />
-      </View>
-    );
-  }
-
   const modeToggle = (
     <View
       style={[
@@ -163,6 +162,13 @@ export default function ScanScreen() {
   );
 
   if (inputMode === 'search') {
+    if (screenState === 'loading') {
+      return (
+        <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
+          <LoadingSpinner message={t('loading')} />
+        </View>
+      );
+    }
     return (
       <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
         {modeToggle}
@@ -205,7 +211,7 @@ export default function ScanScreen() {
     );
   }
 
-  // Camera mode
+  // Camera mode — permission checks
   if (!permission) {
     return (
       <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
@@ -240,21 +246,40 @@ export default function ScanScreen() {
     );
   }
 
+  // Keep CameraView always mounted during loading to prevent iOS re-permission prompt
   return (
     <View style={styles.container}>
-      <CameraView ref={cameraRef} style={styles.camera} facing="back">
+      <CameraView ref={cameraRef} style={styles.camera} facing={facing}>
         <View style={styles.overlay}>
           {modeToggle}
-          <View style={[styles.frame, { borderColor: theme.colors.primary }]} />
-          <Pressable
-            style={[styles.captureButton, { backgroundColor: theme.colors.primary }]}
-            onPress={handleCapture}
-            accessibilityRole="button"
-            accessibilityLabel={t('captureA11y')}
-            accessibilityHint={t('captureHint')}
-          >
-            <View style={[styles.captureInner, { backgroundColor: theme.colors.background }]} />
-          </Pressable>
+          {screenState === 'loading' ? (
+            <LoadingSpinner message={t('loading')} />
+          ) : (
+            <>
+              <View style={[styles.frame, { borderColor: theme.colors.primary }]} />
+              <View style={styles.cameraControls}>
+                <Pressable
+                  style={styles.flipButton}
+                  onPress={() => setFacing((f) => (f === 'back' ? 'front' : 'back'))}
+                  accessibilityRole="button"
+                  accessibilityLabel={t('flipCameraA11y')}
+                >
+                  <Text style={styles.flipButtonText}>{t('flipCamera')}</Text>
+                </Pressable>
+                <Pressable
+                  style={[styles.captureButton, { backgroundColor: theme.colors.primary }]}
+                  onPress={handleCapture}
+                  accessibilityRole="button"
+                  accessibilityLabel={t('captureA11y')}
+                  accessibilityHint={t('captureHint')}
+                >
+                  <View
+                    style={[styles.captureInner, { backgroundColor: theme.colors.background }]}
+                  />
+                </Pressable>
+              </View>
+            </>
+          )}
         </View>
       </CameraView>
 
@@ -300,6 +325,25 @@ const styles = StyleSheet.create({
     height: 340,
     borderWidth: 2,
     borderRadius: 8,
+  },
+  cameraControls: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 24,
+  },
+  flipButton: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(0,0,0,0.45)',
+  },
+  flipButtonText: {
+    color: '#fff',
+    fontWeight: '600',
+    fontSize: 12,
   },
   captureButton: {
     width: 72,

--- a/frontend/src/i18n/locales/_meta/scan.meta.json
+++ b/frontend/src/i18n/locales/_meta/scan.meta.json
@@ -129,5 +129,15 @@
     "description": "Alert message for a wishlist save failure",
     "tone": "friendly",
     "characterLimit": 70
+  },
+  "flipCamera": {
+    "description": "Short label on the button that flips between front and back camera",
+    "tone": "action",
+    "characterLimit": 10
+  },
+  "flipCameraA11y": {
+    "description": "Accessibility label for the flip camera button",
+    "tone": "neutral",
+    "characterLimit": 30
   }
 }

--- a/frontend/src/i18n/locales/en/scan.json
+++ b/frontend/src/i18n/locales/en/scan.json
@@ -26,5 +26,7 @@
   "couldNotSaveTitle": "Could not save",
   "couldNotSaveMessage": "Failed to add book to wishlist. Please try again.",
   "scanUnavailableTitle": "Scan unavailable",
-  "scanUnavailableMessage": "Cover scanning is temporarily unavailable. Try searching by title instead."
+  "scanUnavailableMessage": "Cover scanning is temporarily unavailable. Try searching by title instead.",
+  "flipCamera": "Flip",
+  "flipCameraA11y": "Flip camera"
 }


### PR DESCRIPTION
## Summary
- **Facing toggle**: adds a Flip button in the camera overlay so users can manually switch between front and back camera — needed because iOS Chrome often ignores the `facing="back"` prop on initial mount
- **FormData on web**: detects `Platform.OS === 'web'` and converts the photo URI to a real `Blob` via `fetch()` before appending to `FormData` — the React Native file-object trick is silently ignored by browsers, so the multipart POST was broken on iOS Chrome
- **Camera re-permission prompt**: moves the loading spinner inside the `CameraView` overlay instead of unmounting the camera during loading; this prevents iOS from re-triggering the browser camera permission dialog after every capture attempt

## Test plan
- [x] 23 unit tests added/updated — all pass (`npx jest ScanScreen.test.tsx`)
- [ ] On iOS Chrome: verify Flip button switches between cameras
- [ ] On iOS Chrome: capture a book cover → should show loading → show book picker (no permission dialog reappearing)
- [ ] On iOS Chrome: capture something unrecognisable → "No books found" alert
- [ ] Verify existing search mode and wishlist flows unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)