### PR TITLE
fix: relax OpenAI ISBN prompt to return any edition ISBN

### DIFF
--- a/backend/app/services/chatgpt_vision.py
+++ b/backend/app/services/chatgpt_vision.py
@@ -20,9 +20,10 @@ Each candidate must have:
 - title: string
 - author: string
 - confidence: float between 0 and 1
-- isbn_13: string or null (13-digit ISBN if visible or known)
-- isbn_10: string or null (10-digit ISBN if visible or known)
+- isbn_13: string or null (any valid 13-digit ISBN for this book — any edition is fine)
+- isbn_10: string or null (any valid 10-digit ISBN for this book — any edition is fine)
 
+Provide at least one ISBN whenever you can identify the book, even if you are not certain which specific edition is shown. The ISBN will only be used as a search hint.
 Return ONLY a valid JSON array, no other text. Example:
 [{"title":"Dune","author":"Frank Herbert","confidence":0.97,"isbn_13":"9780441013593","isbn_10":null}]"""
 


### PR DESCRIPTION
## Summary
- Rephrased GPT-4o-mini system prompt to request *any* valid ISBN for the identified book rather than only the exact one shown or known
- Added explicit instruction to provide at least one ISBN whenever the book is identifiable, noting it will only be used as a search hint
- Removes model hesitancy around returning ISBNs for uncertain editions

## Test plan
- [ ] Scan a book cover via the vision path and confirm `isbn_13` or `isbn_10` is now populated in the response
- [ ] Verify barcode scan path is unaffected (uses exact ISBN from the barcode, not this prompt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)