### PR TITLE
fix(ios): production API URL — custom domain + correct Xcode build env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ env/
 .env
 .env.*
 !.env.example
+!.env.production
 *.so
 
 # Alembic

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,1 +1,1 @@
-EXPO_PUBLIC_API_URL=https://bookshelf-api-rxp3.onrender.com
+EXPO_PUBLIC_API_URL=https://bookshelfai.buffingchi.com

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,1 @@
+EXPO_PUBLIC_API_URL=https://bookshelf-api-rxp3.onrender.com

--- a/frontend/eas.json
+++ b/frontend/eas.json
@@ -1,0 +1,26 @@
+{
+  "cli": {
+    "version": ">= 12.0.0"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "env": {
+        "EXPO_PUBLIC_API_URL": "https://bookshelf-api-rxp3.onrender.com"
+      }
+    },
+    "preview": {
+      "distribution": "internal",
+      "env": {
+        "EXPO_PUBLIC_API_URL": "https://bookshelf-api-rxp3.onrender.com"
+      }
+    },
+    "production": {
+      "autoIncrement": true,
+      "env": {
+        "EXPO_PUBLIC_API_URL": "https://bookshelf-api-rxp3.onrender.com"
+      }
+    }
+  }
+}

--- a/frontend/eas.json
+++ b/frontend/eas.json
@@ -7,19 +7,19 @@
       "developmentClient": true,
       "distribution": "internal",
       "env": {
-        "EXPO_PUBLIC_API_URL": "https://bookshelf-api-rxp3.onrender.com"
+        "EXPO_PUBLIC_API_URL": "https://bookshelfai.buffingchi.com"
       }
     },
     "preview": {
       "distribution": "internal",
       "env": {
-        "EXPO_PUBLIC_API_URL": "https://bookshelf-api-rxp3.onrender.com"
+        "EXPO_PUBLIC_API_URL": "https://bookshelfai.buffingchi.com"
       }
     },
     "production": {
       "autoIncrement": true,
       "env": {
-        "EXPO_PUBLIC_API_URL": "https://bookshelf-api-rxp3.onrender.com"
+        "EXPO_PUBLIC_API_URL": "https://bookshelfai.buffingchi.com"
       }
     }
   }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 import * as storage from './storage';
 
-const BASE_URL = process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:8000';
+const BASE_URL = process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:8001';
 
 export const ACCESS_TOKEN_KEY = 'bookshelf_access_token';
 export const REFRESH_TOKEN_KEY = 'bookshelf_refresh_token';


### PR DESCRIPTION
## Problem

The TestFlight build showed a white screen because every API call failed. Two root causes:

1. **Wrong URL baked into the binary** — `EXPO_PUBLIC_API_URL` was unset at build time, so Expo fell back to `localhost:8000` (or `localhost:8001` from `.env.local`). Neither works on a real device.
2. **Hardcoded Render hostname** — even after fixing cause #1, embedding `bookshelf-api-rxp3.onrender.com` directly in the app is brittle (changing hosting = rebuilding and resubmitting the app).

## Solution

### 1. Custom domain (infrastructure)
- Cloudflare CNAME: `bookshelfai.buffingchi.com` → `bookshelf-api-rxp3.onrender.com` (DNS-only, not proxied — Render handles TLS)
- Custom domain registered on the Render service
- The app now points at the stable domain; switching hosting providers only requires updating one DNS record

### 2. Correct dotenv loading for Xcode builds
Expo loads `.env.local` **before** `.env.production`, even when `NODE_ENV=production` (Xcode Release archive). Fix:
- Removed `EXPO_PUBLIC_API_URL` from `.env.local` so it no longer overrides the production URL
- Added committed `.env.production` with `EXPO_PUBLIC_API_URL=https://bookshelfai.buffingchi.com`
- Updated `.gitignore` with `!.env.production` exception

### 3. Miscellaneous
- `eas.json` added with correct domain (unused now, ready if EAS is adopted)
- `api.ts` fallback corrected: `localhost:8000` → `localhost:8001` (matches local dev server)

## File changes

| File | Change |
|------|--------|
| `frontend/.env.production` | New (committed) — production API URL |
| `frontend/.env.local` | Removed `EXPO_PUBLIC_API_URL` |
| `frontend/eas.json` | New — EAS build profiles with correct domain |
| `frontend/lib/api.ts` | Fallback port `8000` → `8001` |
| `.gitignore` | `!.env.production` exception |

## Dotenv resolution after this PR

| Context | Files loaded | `EXPO_PUBLIC_API_URL` |
|---|---|---|
| `npx expo start` (local dev) | `.env.local` (no API URL key) → `.env` | unset → fallback `localhost:8001` ✓ |
| Xcode Release archive | `.env.local` (no API URL key) → `.env.production` | `https://bookshelfai.buffingchi.com` ✓ |

## How to rebuild for TestFlight

1. Merge this PR
2. In Xcode: **Product → Archive** (Release scheme)
3. Distribute to TestFlight as usual

## Test plan
- [ ] Merge PR → `dev`
- [ ] Confirm `bookshelfai.buffingchi.com` resolves (Render domain verification goes green)
- [ ] Archive in Xcode (Release scheme)
- [ ] Install new TestFlight build on device
- [ ] App loads past white screen and login works

🤖 Generated with [Claude Code](https://claude.com/claude-code)