### PR TITLE
feat(infra): custom domains — remove all hardcoded Render hostnames

### DIFF
--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,1 +1,1 @@
-EXPO_PUBLIC_API_URL=https://bookshelfai.buffingchi.com
+EXPO_PUBLIC_API_URL=https://bookshelfapi.buffingchi.com

--- a/frontend/eas.json
+++ b/frontend/eas.json
@@ -7,19 +7,19 @@
       "developmentClient": true,
       "distribution": "internal",
       "env": {
-        "EXPO_PUBLIC_API_URL": "https://bookshelfai.buffingchi.com"
+        "EXPO_PUBLIC_API_URL": "https://bookshelfapi.buffingchi.com"
       }
     },
     "preview": {
       "distribution": "internal",
       "env": {
-        "EXPO_PUBLIC_API_URL": "https://bookshelfai.buffingchi.com"
+        "EXPO_PUBLIC_API_URL": "https://bookshelfapi.buffingchi.com"
       }
     },
     "production": {
       "autoIncrement": true,
       "env": {
-        "EXPO_PUBLIC_API_URL": "https://bookshelfai.buffingchi.com"
+        "EXPO_PUBLIC_API_URL": "https://bookshelfapi.buffingchi.com"
       }
     }
   }

--- a/render.yaml
+++ b/render.yaml
@@ -17,12 +17,13 @@ services:
       - key: ENVIRONMENT
         value: production
       - key: CORS_ORIGINS
-        value: '["https://bookshelf-web-vw0s.onrender.com"]'
+        value: '["https://bookshelfai.buffingchi.com"]'
 
   - type: web
     name: bookshelf-web
     env: static
     region: oregon
+    branch: dev
     buildCommand: npm ci && printf "EXPO_PUBLIC_API_URL=%s\nEXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=%s\n" "$EXPO_PUBLIC_API_URL" "$EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID" > .env && npx expo export --platform web --clear
     staticPublishPath: dist
     rootDir: frontend
@@ -49,7 +50,7 @@ services:
         value: 'max-age=31536000; includeSubDomains'
       - path: /*
         name: Content-Security-Policy
-        value: "default-src 'self'; img-src 'self' https: data:; connect-src 'self' https://bookshelf-api-rxp3.onrender.com; style-src 'self' 'unsafe-inline'; script-src 'self'"
+        value: "default-src 'self'; img-src 'self' https: data:; connect-src 'self' https://bookshelfapi.buffingchi.com; style-src 'self' 'unsafe-inline'; script-src 'self'"
       - path: /*
         name: Cache-Control
         value: no-cache
@@ -58,7 +59,7 @@ services:
         value: 'public, max-age=31536000, immutable'
     envVars:
       - key: EXPO_PUBLIC_API_URL
-        value: https://bookshelf-api-rxp3.onrender.com
+        value: https://bookshelfapi.buffingchi.com
       - key: EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID
         sync: false
 


### PR DESCRIPTION
## Summary

Removes every hardcoded `*.onrender.com` hostname from the codebase and routes traffic through stable custom subdomains on `buffingchi.com`.

## Domain split

| Subdomain | Points to | Purpose |
|---|---|---|
| `bookshelfai.buffingchi.com` | `bookshelf-web-vw0s.onrender.com` | Web UI |
| `bookshelfapi.buffingchi.com` | `bookshelf-api-rxp3.onrender.com` | API |

Both CNAMEs are DNS-only (not Cloudflare-proxied) so Render can provision its own TLS certs.

## Infrastructure changes (already applied)

- Cloudflare: `bookshelfai` CNAME updated to web frontend; `bookshelfapi` CNAME created for API
- Render `bookshelf-web`: custom domain `bookshelfai.buffingchi.com` added, branch set to `dev`
- Render `bookshelf-api`: old `bookshelfai` custom domain removed, `bookshelfapi.buffingchi.com` added

## Code changes (`render.yaml`)

- `CORS_ORIGINS` updated to `bookshelfai.buffingchi.com`
- CSP `connect-src` updated to `bookshelfapi.buffingchi.com`
- `EXPO_PUBLIC_API_URL` updated to `bookshelfapi.buffingchi.com`
- `bookshelf-web` branch explicitly set to `dev`

## Subpage routing

Already correct — `bookshelf-web` has a `/* -> /index.html` rewrite rule, so all Expo Router paths resolve to the SPA correctly.

## Related

Companion PR for iOS build fix: #109 (also updates `.env.production` and `eas.json` to `bookshelfapi.buffingchi.com`)

## Test plan
- [ ] Merge PR
- [ ] Visit `https://bookshelfai.buffingchi.com` — web login screen loads
- [ ] Visit `https://bookshelfai.buffingchi.com/login` directly — still loads (SPA routing)
- [ ] Visit `https://bookshelfapi.buffingchi.com/health` — returns `{"status":"ok"}`
- [ ] Confirm both Render custom domains show as verified in the Render dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)