### PR TITLE
fix(web): COOP header same-origin-allow-popups for Google OAuth

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -35,7 +35,7 @@ services:
     headers:
       - path: /*
         name: Cross-Origin-Opener-Policy
-        value: unsafe-none
+        value: same-origin-allow-popups
       - path: /*
         name: X-Frame-Options
         value: DENY


### PR DESCRIPTION
## Problem

Google OAuth login on web fails silently — user picks their account then gets redirected back to the login screen.

Two issues observed in the browser console:

1. `Cross-Origin-Opener-Policy policy would block the window.closed call` — the COOP header was `unsafe-none`, which causes the Google OAuth popup to lose its browsing context connection. `expo-web-browser` polls `popup.closed` to detect when the auth session ends; when this is blocked the response never gets processed cleanly.

2. CORS error hitting `bookshelf-api-rxp3.onrender.com` from `bookshelfai.buffingchi.com` — the old Render URL was still baked into the web build and `bookshelfai.buffingchi.com` was not in the CORS allowlist.

## Fix

**`render.yaml`** — change `Cross-Origin-Opener-Policy` from `unsafe-none` to `same-origin-allow-popups`.

`same-origin-allow-popups` keeps the opener page in the same browsing context group as popups it opens, which is what `expo-web-browser` requires for OAuth popup flows. It also maintains necessary security isolation with cross-origin iframes.

## Immediate hotfixes already applied (live now)

- `bookshelf-api` CORS_ORIGINS updated to `["https://bookshelfai.buffingchi.com"]` via Render API
- `bookshelf-web` `EXPO_PUBLIC_API_URL` updated to `https://bookshelfapi.buffingchi.com` via Render API
- Both services redeployed

This PR captures the COOP header fix so it persists after the next `render.yaml`-driven deploy.

## Test plan
- [ ] Merge PR
- [ ] Visit `https://bookshelfai.buffingchi.com`
- [ ] Click "Sign in with Google", select account
- [ ] Confirm redirect to the app's main screen (not back to login)

🤖 Generated with [Claude Code](https://claude.com/claude-code)