### PR TITLE
fix(ios): add Xcode Cloud ci_post_clone.sh to run pod install before archive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ Monorepo: `backend/` · `frontend/` · `.github/` · `docs/`
 - [Backend](docs/claude/backend.md)
 - [Frontend](docs/claude/frontend.md)
 - [Testing](docs/claude/testing.md)
+- [iOS CI/CD](docs/claude/ios-ci.md)      ← Xcode Cloud build setup (NOT EAS)
 
 ## Hard Rules (no exceptions)
 1. NEVER push to `dev` or `main` directly.

--- a/docs/claude/ios-ci.md
+++ b/docs/claude/ios-ci.md
@@ -1,0 +1,54 @@
+# iOS CI/CD — Build Infrastructure
+
+## IMPORTANT: We use Xcode Cloud, NOT EAS Build
+
+iOS builds and App Store submissions run through **Xcode Cloud** (Apple's CI,
+`/Volumes/workspace/` on the build worker). EAS Build is NOT used. Do not
+suggest EAS-specific fixes (e.g. `eas.json` resource classes) for Xcode Cloud
+build failures.
+
+## Why `pod install` must run in CI
+
+`Pods/` is listed in `frontend/ios/.gitignore` and is never committed. Xcode
+Cloud clones the repo and jumps straight to `xcodebuild archive`, which fails
+with:
+
+```
+Unable to open base configuration reference file
+  …/Pods/Target Support Files/Pods-Bookshelf/Pods-Bookshelf.release.xcconfig
+```
+
+## The fix: `ci_scripts/ci_post_clone.sh`
+
+Xcode Cloud automatically executes
+`frontend/ios/ci_scripts/ci_post_clone.sh` after cloning. This script runs
+`npm ci` (required for React Native's pod scripts) then `pod install`.
+
+File: `frontend/ios/ci_scripts/ci_post_clone.sh`
+
+```sh
+#!/bin/sh
+set -e
+cd "$CI_PRIMARY_REPOSITORY_PATH/frontend"
+npm ci
+cd ios
+pod install
+```
+
+The script must be **executable** (`chmod +x`). Git preserves the execute bit
+via `core.fileMode` — verify with `git ls-files --stage frontend/ios/ci_scripts/`.
+
+## Bare workflow
+
+`frontend/ios/` is committed (bare Expo workflow). Running `expo prebuild`
+locally regenerates it; Xcode Cloud does NOT run prebuild — it uses the
+committed `ios/` directory directly.
+
+## Key paths on the Xcode Cloud worker
+
+| Path | What it is |
+|---|---|
+| `/Volumes/workspace/repository/` | Repo root |
+| `/Volumes/workspace/repository/frontend/ios/Bookshelf.xcworkspace` | Workspace opened by Xcode Cloud |
+| `/Volumes/workspace/build.xcarchive` | Output archive |
+| `/Volumes/workspace/DerivedData` | Build intermediates |

--- a/frontend/ios/ci_scripts/ci_post_clone.sh
+++ b/frontend/ios/ci_scripts/ci_post_clone.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Xcode Cloud: runs automatically after the repo is cloned.
+# Pods/ is gitignored, so we must run pod install before xcodebuild archive.
+set -e
+
+# Node modules are required for React Native's pod scripts (e.g. react-native-codegen).
+cd "$CI_PRIMARY_REPOSITORY_PATH/frontend"
+npm ci
+
+# Install CocoaPods dependencies.
+cd ios
+pod install


### PR DESCRIPTION
## Summary
- Adds `frontend/ios/ci_scripts/ci_post_clone.sh` — Xcode Cloud runs this automatically after clone, before `xcodebuild archive`
- Script runs `npm ci` (needed for React Native pod scripts) then `pod install`
- Adds `docs/claude/ios-ci.md` documenting that this project uses **Xcode Cloud, not EAS Build**
- Updates `CLAUDE.md` to reference the new iOS CI doc

## Root cause
`Pods/` is gitignored. Xcode Cloud was cloning the repo and jumping straight to `xcodebuild archive` with no CocoaPods setup, failing with:
```
Unable to open base configuration reference file
  …/Pods/Target Support Files/Pods-Bookshelf/Pods-Bookshelf.release.xcconfig
```

## Test plan
- [ ] Trigger a new Xcode Cloud build — confirm `ci_post_clone.sh` appears in the build log
- [ ] Confirm `pod install` completes without error
- [ ] Confirm `xcodebuild archive` succeeds (exit code 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)