### PR TITLE
fix(ios): install node via brew and fix execute bit on ci_post_clone.sh

### DIFF
--- a/frontend/ios/ci_scripts/ci_post_clone.sh
+++ b/frontend/ios/ci_scripts/ci_post_clone.sh
@@ -1,12 +1,16 @@
-#!/bin/sh
+#!/bin/zsh
 # Xcode Cloud: runs automatically after the repo is cloned.
-# Pods/ is gitignored, so we must run pod install before xcodebuild archive.
+# Node.js is not pre-installed on Xcode Cloud workers — install via Homebrew.
+# Pods/ is gitignored, so pod install must run before xcodebuild archive.
 set -e
 
-# Node modules are required for React Native's pod scripts (e.g. react-native-codegen).
+# Install Node.js
+brew install node
+
+# Install Node.js dependencies (required for React Native pod scripts)
 cd "$CI_PRIMARY_REPOSITORY_PATH/frontend"
 npm ci
 
-# Install CocoaPods dependencies.
+# Install CocoaPods dependencies
 cd ios
 pod install


### PR DESCRIPTION
## Summary
- `brew install node` added before `npm ci` — Node.js is not pre-installed on Xcode Cloud workers
- Shebang changed to `#!/bin/zsh` (Xcode Cloud's default shell)
- Execute bit set via `git update-index --chmod=+x` (mode `100755` confirmed)

## Previous failure
```
ci_post_clone.sh:8: command not found: npm
exited with code 127
```
Node wasn't on PATH because it was never installed on the worker. The script also wasn't executable so Xcode Cloud fell back to running it via `zsh` directly.

## Test plan
- [ ] Trigger a new Xcode Cloud build
- [ ] Confirm `brew install node` and `pod install` appear in the `ci_post_clone.sh` log
- [ ] Confirm `xcodebuild archive` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)