### PR TITLE
feat(observability): add Sentry error and performance monitoring

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -15,6 +15,9 @@ OPENAI_API_KEY=
 GOOGLE_BOOKS_API_KEY=
 OPEN_LIBRARY_BASE_URL=https://openlibrary.org
 
+# Observability
+SENTRY_DSN=          # optional — leave blank to disable Sentry
+
 # App
 ENVIRONMENT=development
 CORS_ORIGINS=http://localhost:8081,exp://localhost:8081

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -23,6 +23,9 @@ class Settings(BaseSettings):
     google_books_api_key: str = ""
     open_library_base_url: str = "https://openlibrary.org"
 
+    # Observability
+    sentry_dsn: str = ""
+
     # App
     environment: str = "development"
     cors_origins: list[str] = []

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,8 +1,11 @@
 import logging
 
+import sentry_sdk
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from sentry_sdk.integrations.fastapi import FastApiIntegration
+from sentry_sdk.integrations.starlette import StarletteIntegration
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from sqlalchemy import text
@@ -20,6 +23,18 @@ from app.core.limiter import limiter
 from app.core.logging import configure_logging, new_request_id, request_id_var
 
 configure_logging()
+
+if settings.sentry_dsn:
+    sentry_sdk.init(
+        dsn=settings.sentry_dsn,
+        environment=settings.environment,
+        integrations=[
+            StarletteIntegration(transaction_style="endpoint"),
+            FastApiIntegration(transaction_style="endpoint"),
+        ],
+        traces_sample_rate=0.2 if settings.environment == "production" else 1.0,
+        send_default_pii=False,
+    )
 
 logger = logging.getLogger(__name__)
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,4 @@ httpx==0.28.1
 slowapi==0.1.9
 python-multipart==0.0.22
 cryptography>=43.0.0
+sentry-sdk[fastapi]==2.27.0

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -49,7 +49,8 @@
         {
           "cameraPermission": "Allow Bookshelf to use the camera to scan book covers."
         }
-      ]
+      ],
+      "@sentry/react-native/expo"
     ],
     "scheme": "bookshelf"
   }

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -5,9 +5,12 @@ import { Stack } from 'expo-router';
 import { ErrorBoundary } from '../components/ErrorBoundary';
 import { ThemeToggleButton } from '../components/ThemeToggleButton';
 import { AuthProvider } from '../contexts/AuthContext';
+import { initSentry, Sentry } from '../lib/sentry';
 import { ThemeProvider } from '../theme';
 
-export default function RootLayout() {
+initSentry();
+
+function RootLayout() {
   return (
     <ErrorBoundary>
       <ThemeProvider>
@@ -22,3 +25,5 @@ export default function RootLayout() {
     </ErrorBoundary>
   );
 }
+
+export default Sentry.wrap(RootLayout);

--- a/frontend/components/ErrorBoundary.tsx
+++ b/frontend/components/ErrorBoundary.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 
+import { Sentry } from '../lib/sentry';
+
 interface Props {
   children: React.ReactNode;
 }
@@ -21,6 +23,7 @@ export class ErrorBoundary extends React.Component<Props, State> {
 
   componentDidCatch(error: Error, info: React.ErrorInfo) {
     console.error('[ErrorBoundary] Unhandled error:', error, info.componentStack);
+    Sentry.captureException(error, { extra: { componentStack: info.componentStack } });
   }
 
   render() {

--- a/frontend/lib/sentry.ts
+++ b/frontend/lib/sentry.ts
@@ -1,0 +1,18 @@
+import * as Sentry from '@sentry/react-native';
+
+const DSN = process.env.EXPO_PUBLIC_SENTRY_DSN;
+
+export function initSentry(): void {
+  if (!DSN) return;
+
+  Sentry.init({
+    dsn: DSN,
+    environment: process.env.EXPO_PUBLIC_ENVIRONMENT ?? 'development',
+    // Capture 20% of transactions in production to keep quota manageable
+    tracesSampleRate: process.env.EXPO_PUBLIC_ENVIRONMENT === 'production' ? 0.2 : 1.0,
+    sendDefaultPii: false,
+    enabled: !!DSN,
+  });
+}
+
+export { Sentry };

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@expo/vector-icons": "^14.0.2",
+        "@sentry/react-native": "^8.6.0",
         "@tanstack/react-query": "^5.59.0",
         "axios": "^1.14.0",
         "expo": "~51.0.28",
@@ -6004,6 +6005,318 @@
       "dependencies": {
         "component-type": "^1.2.1",
         "join-component": "^1.1.0"
+      }
+    },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.46.0.tgz",
+      "integrity": "sha512-WB1gBT9G13V02ekZ6NpUhoI1aGHV2eNfjEPthkU2bGBvFpQKnstwzjg7waIRGR7cu+YSW2Q6UI6aQLgBeOPD1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.46.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.46.0.tgz",
+      "integrity": "sha512-c4pI/z9nZCQXe9GYEw/hE/YTY9AxGBp8/wgKI+T8zylrN35SGHaXv63szzE1WbI8lacBY8lBF7rstq9bQVCaHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.46.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.46.0.tgz",
+      "integrity": "sha512-JBsWeXG6bRbxBFK8GzWymWGOB9QE7Kl57BeF3jzgdHTuHSWZ2mRnAmb1K05T4LU+gVygk6yW0KmdC8Py9Qzg9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.46.0",
+        "@sentry/core": "10.46.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.46.0.tgz",
+      "integrity": "sha512-ub314MWUsekVCuoH0/HJbbimlI24SkV745UW2pj9xRbxOAEf1wjkmIzxKrMDbTgJGuEunug02XZVdJFJUzOcDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "10.46.0",
+        "@sentry/core": "10.46.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/babel-plugin-component-annotate": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-5.1.1.tgz",
+      "integrity": "sha512-x2wEpBHwsTyTF2rWsLKJlzrRF1TTIGOfX+ngdE+Yd5DBkoS58HwQv824QOviPGQRla4/ypISqAXzjdDPL/zalg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.46.0.tgz",
+      "integrity": "sha512-80DmGlTk5Z2/OxVOzLNxwolMyouuAYKqG8KUcoyintZqHbF6kO1RulI610HmyUt3OagKeBCqt9S7w0VIfCRL+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.46.0",
+        "@sentry-internal/feedback": "10.46.0",
+        "@sentry-internal/replay": "10.46.0",
+        "@sentry-internal/replay-canvas": "10.46.0",
+        "@sentry/core": "10.46.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-3.3.4.tgz",
+      "integrity": "sha512-r97H1GTdaRs1qhTvbzyomclPesrt4vpjY2W7KGtgSOa5ynQsXKajsM5oJOtNW99O1pNNMZFlR1mmGDMHOxYm4g==",
+      "hasInstallScript": true,
+      "license": "FSL-1.1-MIT",
+      "dependencies": {
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "undici": "^6.22.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "3.3.4",
+        "@sentry/cli-linux-arm": "3.3.4",
+        "@sentry/cli-linux-arm64": "3.3.4",
+        "@sentry/cli-linux-i686": "3.3.4",
+        "@sentry/cli-linux-x64": "3.3.4",
+        "@sentry/cli-win32-arm64": "3.3.4",
+        "@sentry/cli-win32-i686": "3.3.4",
+        "@sentry/cli-win32-x64": "3.3.4"
+      }
+    },
+    "node_modules/@sentry/cli-darwin": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-3.3.4.tgz",
+      "integrity": "sha512-1cFHgwJq0yJ4lAvxQISag2R5R/wRtY7e4YX54Da4n+Isw1WHdF2CLmdT0ufOyT04iiF406UD2d7qsPEVDniAmw==",
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-3.3.4.tgz",
+      "integrity": "sha512-8XDDmUZ/4X7Dw2hoSU6T9tpD8qMwtVKHYLQjcY+xNBQujPrSq+YCrNXK/iIN9UgX8Rza2q4IftsIkJADOxLFow==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-3.3.4.tgz",
+      "integrity": "sha512-SD9YQjUPXjIBkt4q41lHMopeL9lKskaxc7qpt1ZuQpoHOszDOUNP3WPvxpeiaMjFMmgMkGojyDBk2XY9eyfGNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-3.3.4.tgz",
+      "integrity": "sha512-LNQlRDPrHLTDgxxJsAzT+1+sJ8Kv/Lq8E4Ob8RjqkwuZxl/wR6QJ4O83cxYGJPPnmjEAT+lOUQt1pTPXAwIwLQ==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-3.3.4.tgz",
+      "integrity": "sha512-yEOVI4a0RTBYcHJBEaiFU2s4GzcfkXDToMUeLlUg4B3Bgz8AX76163RTEJH5dKavKkoMLKzOrKgVylXPxo1JLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-win32-arm64": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-3.3.4.tgz",
+      "integrity": "sha512-aLGgnIf7FHK+yRsemXGQ1yF0Q4R3D/jwCf/20k1miUgFP9fn5mZt+fArGDHr5k3vFfh3bUTf22Ga4CUwXqwkvQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-3.3.4.tgz",
+      "integrity": "sha512-mLD5NpgI3G3+f1iBWGqTTC1kvdQ0CzmkvM9aIRiXUYWXZiaZVd4YuqhoDvTU6zNFEUXI+9jUEp84VF171B0Pqg==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-3.3.4.tgz",
+      "integrity": "sha512-dNWifGo3VLx7n3N3/m+7+rLGNZEb7JmnLwLLAHoz11DneCa6OTBSMCKFABArxqLinlzTbiSOYc8QbvCTcLk5FA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli/node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.46.0.tgz",
+      "integrity": "sha512-N3fj4zqBQOhXliS1Ne9euqIKuciHCGOJfPGQLwBoW9DNz03jF+NB8+dUKtrJ79YLoftjVgf8nbgwtADK7NR+2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.46.0.tgz",
+      "integrity": "sha512-Rb1S+9OuUPVwsz7GWnQ6Kgf3azbsseUymIegg3JZHNcW/fM1nPpaljzTBnuineia113DH0pgMBcdrrZDLaosFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.46.0",
+        "@sentry/core": "10.46.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/react-native": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-8.6.0.tgz",
+      "integrity": "sha512-sT44HU09BCxlFndTJaYJjxkd6OGAiTLd85rgXkShlllur5ITDg7GZmVgTv/ja4bPOqSMHAGMI9Tx3/VTDq3dgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/babel-plugin-component-annotate": "5.1.1",
+        "@sentry/browser": "10.46.0",
+        "@sentry/cli": "3.3.4",
+        "@sentry/core": "10.46.0",
+        "@sentry/react": "10.46.0",
+        "@sentry/types": "10.46.0"
+      },
+      "bin": {
+        "sentry-eas-build-on-complete": "scripts/eas-build-hook.js",
+        "sentry-eas-build-on-error": "scripts/eas-build-hook.js",
+        "sentry-eas-build-on-success": "scripts/eas-build-hook.js",
+        "sentry-expo-upload-sourcemaps": "scripts/expo-upload-sourcemaps.js"
+      },
+      "peerDependencies": {
+        "expo": ">=49.0.0",
+        "react": ">=17.0.0",
+        "react-native": ">=0.65.0"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/types": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-10.46.0.tgz",
+      "integrity": "sha512-ZJWEuevCTzxA2z+C5NQ+bXKxA+oVnZM5QacBZ+RX6NHItwgYOcp4GNM6Wc9xTymOUvVmBC0Vcj1wbx7TA2JX0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.46.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sideway/address": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^14.0.2",
+    "@sentry/react-native": "^8.6.0",
     "@tanstack/react-query": "^5.59.0",
     "axios": "^1.14.0",
     "expo": "~51.0.28",
@@ -65,7 +66,7 @@
       "!src/i18n/glossary.ts"
     ],
     "transformIgnorePatterns": [
-      "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|i18next|react-i18next|i18next-resources-to-backend)"
+      "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|@sentry/.*|native-base|react-native-svg|i18next|react-i18next|i18next-resources-to-backend)"
     ]
   },
   "prettier": {

--- a/render.yaml
+++ b/render.yaml
@@ -24,7 +24,7 @@ services:
     env: static
     region: oregon
     branch: dev
-    buildCommand: npm ci && printf "EXPO_PUBLIC_API_URL=%s\nEXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=%s\n" "$EXPO_PUBLIC_API_URL" "$EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID" > .env && npx expo export --platform web --clear
+    buildCommand: npm ci && printf "EXPO_PUBLIC_API_URL=%s\nEXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=%s\nEXPO_PUBLIC_SENTRY_DSN=%s\nEXPO_PUBLIC_ENVIRONMENT=%s\n" "$EXPO_PUBLIC_API_URL" "$EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID" "$EXPO_PUBLIC_SENTRY_DSN" "$EXPO_PUBLIC_ENVIRONMENT" > .env && npx expo export --platform web --clear
     staticPublishPath: dist
     rootDir: frontend
     pullRequestPreviewsEnabled: false
@@ -62,6 +62,10 @@ services:
         value: https://bookshelfapi.buffingchi.com
       - key: EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID
         sync: false
+      - key: EXPO_PUBLIC_SENTRY_DSN
+        sync: false
+      - key: EXPO_PUBLIC_ENVIRONMENT
+        value: production
 
 databases:
   - name: bookshelf-db


### PR DESCRIPTION
## Summary
- **Backend**: initialises `sentry-sdk[fastapi]` with Starlette + FastAPI integrations; DSN-gated so local dev with no `SENTRY_DSN` is a no-op; 20 % `traces_sample_rate` in production, 100 % in other envs; `send_default_pii=False`
- **Frontend**: installs `@sentry/react-native`; `lib/sentry.ts` handles init (guarded by `EXPO_PUBLIC_SENTRY_DSN`); root layout wrapped with `Sentry.wrap()` for native crash tracking; `ErrorBoundary.componentDidCatch` calls `Sentry.captureException`
- **Config**: `.env.example` documents `SENTRY_DSN`; `app.json` adds `@sentry/react-native/expo` plugin; Jest `transformIgnorePatterns` updated for `@sentry/*`

## Env vars to set
| Service | Var | Where |
|---|---|---|
| Backend (Render) | `SENTRY_DSN` | Render env vars |
| Frontend (Expo) | `EXPO_PUBLIC_SENTRY_DSN` | EAS secrets / local `.env` |
| Frontend (Expo) | `EXPO_PUBLIC_ENVIRONMENT` | EAS secrets / local `.env` |

## Test plan
- [ ] Add `SENTRY_DSN` to Render backend env — confirm startup log shows no Sentry errors
- [ ] Trigger a handled exception in the API — verify it appears in Sentry Issues
- [ ] Add `EXPO_PUBLIC_SENTRY_DSN` to EAS / local `.env` — confirm init logs on app start
- [ ] Force an error in a component — confirm `ErrorBoundary` catches it and Sentry receives the event
- [ ] All 146 frontend unit tests pass (`npx jest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)