### PR TITLE
fix(backend): add jinja2 dep required by sentry StarletteIntegration

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,3 +13,4 @@ slowapi==0.1.9
 python-multipart==0.0.22
 cryptography>=43.0.0
 sentry-sdk[fastapi]==2.27.0
+jinja2>=3.1.0


### PR DESCRIPTION
## Problem
Deploy crashing on startup after Sentry was added:
```
ImportError: jinja2 must be installed to use Jinja2Templates
```
`sentry-sdk`'s `StarletteIntegration` patches `Jinja2Templates` during init. Since the app is a pure JSON API, `jinja2` was never in `requirements.txt`.

## Fix
Add `jinja2>=3.1.0` to `requirements.txt`.

## Test plan
- [ ] `bookshelf-api` deploy succeeds and `/health` returns `{"status":"ok"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)