### PR TITLE
fix(ios): allow Sentry upload to fail in Xcode Cloud

### DIFF
--- a/frontend/ios/ci_scripts/ci_post_clone.sh
+++ b/frontend/ios/ci_scripts/ci_post_clone.sh
@@ -4,6 +4,10 @@
 # Pods/ is gitignored, so pod install must run before xcodebuild archive.
 set -e
 
+# Allow Sentry source-map upload to fail gracefully in CI
+# (org/project/auth token must be configured as Xcode Cloud env vars)
+export SENTRY_ALLOW_FAILURE=true
+
 # Install Node.js
 brew install node
 


### PR DESCRIPTION
## Summary
- Xcode Cloud archive fails because `sentry-cli` requires `--org` but `sentry.properties` only has the URL — org/project/auth token are expected as env vars (`SENTRY_ORG`, `SENTRY_PROJECT`, `SENTRY_AUTH_TOKEN`) which aren't configured yet
- Exports `SENTRY_ALLOW_FAILURE=true` in `ci_post_clone.sh` so the build continues when source-map upload fails
- Once Sentry env vars are added in Xcode Cloud settings, uploads will work automatically

## Test plan
- [ ] Verify Xcode Cloud archive build passes the "Bundle React Native code and images" phase
- [ ] Confirm Sentry warning appears in build logs but doesn't fail the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)