### PR TITLE
fix(ios): set SENTRY_ALLOW_FAILURE in .xcode.env

### DIFF
--- a/frontend/ios/.xcode.env
+++ b/frontend/ios/.xcode.env
@@ -9,3 +9,7 @@
 # For example, to use nvm with brew, add the following line
 # . "$(brew --prefix nvm)/nvm.sh" --no-use
 export NODE_BINARY=$(command -v node)
+
+# Allow Sentry source-map upload to fail gracefully in CI
+# (configure SENTRY_ORG, SENTRY_PROJECT, SENTRY_AUTH_TOKEN in Xcode Cloud env vars to enable uploads)
+export SENTRY_ALLOW_FAILURE=true


### PR DESCRIPTION
## Summary
- Xcode Cloud archive fails because `sentry-cli` requires `--org` but `sentry.properties` has no org/project values
- The `SENTRY_ALLOW_FAILURE=true` in `ci_post_clone.sh` (merged in #122) doesn't work because env vars from that script don't persist into Xcode build phase processes
- Adds `SENTRY_ALLOW_FAILURE=true` to `.xcode.env`, which is explicitly sourced by the "Bundle React Native code and images" build phase before invoking `sentry-xcode.sh`

## Test plan
- [ ] Verify Xcode Cloud archive passes the "Bundle React Native code and images" phase
- [ ] Confirm Sentry logs a warning but does not fail the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)