### PR TITLE
fix(sentry): wire SENTRY_DSN to Render and add debug test endpoint

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -167,3 +167,11 @@ async def health(request: Request) -> JSONResponse:
         status_code=200 if healthy else 503,
         content={"status": "ok" if healthy else "degraded", "db": db_status},
     )
+
+
+if settings.environment != "production":
+
+    @app.get("/debug/sentry-test")
+    @limiter.limit("5/minute")
+    async def sentry_test(request: Request) -> JSONResponse:
+        1 / 0  # intentional — triggers Sentry capture

--- a/render.yaml
+++ b/render.yaml
@@ -22,6 +22,8 @@ services:
         value: '["bookshelfapi.buffingchi.com"]'
       - key: TURNSTILE_SECRET_KEY
         sync: false
+      - key: SENTRY_DSN
+        sync: false
 
   - type: web
     name: bookshelf-web


### PR DESCRIPTION
## Summary
- Adds `SENTRY_DSN: sync: false` to the `bookshelf-api` service in `render.yaml` — this key was absent entirely, so `sentry_sdk.init()` was never called in production
- Adds `GET /debug/sentry-test` endpoint to the backend (non-production only) that triggers a `ZeroDivisionError` — use this after deploying to verify Sentry captures the event
- `EXPO_PUBLIC_SENTRY_DSN` was already declared in `render.yaml` for the frontend; its value just needs to be set in the Render dashboard

## After merging — manual steps (run from Codespace)
1. Get service IDs:
   ```bash
   curl -s -H "Authorization: Bearer $RENDER_API_KEY" "https://api.render.com/v1/services?name=bookshelf-api&limit=1" | jq '.[0].service.id'
   curl -s -H "Authorization: Bearer $RENDER_API_KEY" "https://api.render.com/v1/services?name=bookshelf-web&limit=1" | jq '.[0].service.id'
   ```
2. Check if vars are already set (read-only):
   ```bash
   curl -s -H "Authorization: Bearer $RENDER_API_KEY" "https://api.render.com/v1/services/$API_SVC_ID/env-vars" | jq '.[] | select(.key=="SENTRY_DSN")'
   curl -s -H "Authorization: Bearer $RENDER_API_KEY" "https://api.render.com/v1/services/$WEB_SVC_ID/env-vars" | jq '.[] | select(.key=="EXPO_PUBLIC_SENTRY_DSN")'
   ```
3. Add missing vars via POST (safe — does not touch other vars):
   ```bash
   curl -s -X POST -H "Authorization: Bearer $RENDER_API_KEY" -H "Content-Type: application/json" "https://api.render.com/v1/services/$API_SVC_ID/env-vars" -d "[{\"key\":\"SENTRY_DSN\",\"value\":\"$SENTRY_DSN\"}]"
   curl -s -X POST -H "Authorization: Bearer $RENDER_API_KEY" -H "Content-Type: application/json" "https://api.render.com/v1/services/$WEB_SVC_ID/env-vars" -d "[{\"key\":\"EXPO_PUBLIC_SENTRY_DSN\",\"value\":\"$EXPO_PUBLIC_SENTRY_DSN\"}]"
   ```
4. Trigger redeploy, then hit `GET /debug/sentry-test` — expect a 500 and a `ZeroDivisionError` event in the Sentry dashboard within ~30s

## Test plan
- [ ] CI passes
- [ ] Both Render services have real DSN values set (Step 2 above returns a non-empty value)
- [ ] `GET /health` returns 200 after redeploy
- [ ] `GET /debug/sentry-test` produces a Sentry event
- [ ] Web app loads with no Sentry init errors in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)