### PR TITLE
fix(ios): prevent startup crash and ensure Sentry captures early errors

### DIFF
--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,3 +1,5 @@
 EXPO_PUBLIC_API_URL=https://bookshelfapi.buffingchi.com
+EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=648904540482-adeo13bqnptm6044dkg0168n7706lhnt.apps.googleusercontent.com
+EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID=648904540482-07ckrnvv97q5if96fh3sjjj2kmet306n.apps.googleusercontent.com
 EXPO_PUBLIC_SENTRY_DSN=https://8d7985b74e3df0be133eb2d78d27a8c3@o4511129011093504.ingest.us.sentry.io/4511129213927424
 EXPO_PUBLIC_ENVIRONMENT=production

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -1,3 +1,7 @@
+// Sentry MUST be the first import — its module self-initialises so the
+// native crash reporter is ready before any other module can throw.
+import { Sentry } from '../lib/sentry';
+
 import '../src/i18n/i18n';
 
 import { Stack } from 'expo-router';
@@ -5,10 +9,7 @@ import { Stack } from 'expo-router';
 import { ErrorBoundary } from '../components/ErrorBoundary';
 import { ThemeToggleButton } from '../components/ThemeToggleButton';
 import { AuthProvider } from '../contexts/AuthContext';
-import { initSentry, Sentry } from '../lib/sentry';
 import { ThemeProvider } from '../theme';
-
-initSentry();
 
 function RootLayout() {
   return (

--- a/frontend/lib/sentry.ts
+++ b/frontend/lib/sentry.ts
@@ -2,17 +2,33 @@ import * as Sentry from '@sentry/react-native';
 
 const DSN = process.env.EXPO_PUBLIC_SENTRY_DSN;
 
+/**
+ * Initialise Sentry.  Safe to call more than once — subsequent calls are
+ * no-ops because the SDK ignores re-initialisation.
+ *
+ * Wrapped in try/catch so a native-module error during init can never
+ * escalate to RCTFatal and crash the app before anything renders.
+ */
 export function initSentry(): void {
   if (!DSN) return;
 
-  Sentry.init({
-    dsn: DSN,
-    environment: process.env.EXPO_PUBLIC_ENVIRONMENT ?? 'development',
-    // Capture 20% of transactions in production to keep quota manageable
-    tracesSampleRate: process.env.EXPO_PUBLIC_ENVIRONMENT === 'production' ? 0.2 : 1.0,
-    sendDefaultPii: false,
-    enabled: !!DSN,
-  });
+  try {
+    Sentry.init({
+      dsn: DSN,
+      environment: process.env.EXPO_PUBLIC_ENVIRONMENT ?? 'development',
+      // Capture 20% of transactions in production to keep quota manageable
+      tracesSampleRate: process.env.EXPO_PUBLIC_ENVIRONMENT === 'production' ? 0.2 : 1.0,
+      sendDefaultPii: false,
+      enabled: !!DSN,
+    });
+  } catch (e) {
+    // Log but never crash — the app must boot even if Sentry is broken.
+    console.error('[Sentry] init failed:', e);
+  }
 }
+
+// Self-initialise on import so Sentry is ready before any other module
+// evaluates.  _layout.tsx must import this file FIRST.
+initSentry();
 
 export { Sentry };


### PR DESCRIPTION
## Summary
- **Root cause:** `Sentry.init()` had no try-catch — a native-module error during first boot escalated through `RCTCxxBridge handleError:` → `RCTFatal` → `SIGABRT`, crashing the app ~333ms after launch
- **Sentry blindness:** Sentry initialized *after* i18n, SecureStore, AuthProvider, and other imports — any error during that module-evaluation window was invisible
- **Missing env vars:** `.env.production` (only env file available in Xcode Cloud) was missing Google OAuth client IDs

## Changes
- Wrap `Sentry.init()` in try-catch so it can never crash the app
- Self-initialise Sentry on import and move it to the first import in `_layout.tsx`
- Add missing `EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID` and `EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID` to `.env.production`

## Test plan
- [x] All 147 frontend tests pass
- [ ] Trigger a TestFlight build and verify the app no longer crashes at startup
- [ ] Verify Sentry receives error reports from the production build
- [ ] Verify Google OAuth login works on iOS TestFlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)