### PR TITLE
fix(ios): native Sentry init + catch uncaught i18n promise

### DIFF
--- a/frontend/ios/BookShelfAI.xcodeproj/project.pbxproj
+++ b/frontend/ios/BookShelfAI.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		B18059E884C0ABDD17F3DC3D /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC715A2D49A985799AEE119 /* ExpoModulesProvider.swift */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
 		D7A7F0290DD646D1801C9C00 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D2B58053770444BF952B66F8 /* PrivacyInfo.xcprivacy */; };
+		E1A2B3C4D5E6F708A9B0C1D2 /* sentry.options.json in Resources */ = {isa = PBXBuildFile; fileRef = F0E1D2C3B4A596870FEDCBA9 /* sentry.options.json */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -34,6 +35,7 @@
 		D2B58053770444BF952B66F8 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = PrivacyInfo.xcprivacy; path = BookShelfAI/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		F6B72321766C4777B9B8F4E7 /* BookShelfAI-Bridging-Header.h */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.h; name = "BookShelfAI-Bridging-Header.h"; path = "BookShelfAI/BookShelfAI-Bridging-Header.h"; sourceTree = "<group>"; };
+		F0E1D2C3B4A596870FEDCBA9 /* sentry.options.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "sentry.options.json"; path = "BookShelfAI/sentry.options.json"; sourceTree = "<group>"; };
 		FAC715A2D49A985799AEE119 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-BookShelfAI/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -60,6 +62,7 @@
 				13B07FB71A68108700A75B9A /* main.m */,
 				AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */,
 				D2B58053770444BF952B66F8 /* PrivacyInfo.xcprivacy */,
+				F0E1D2C3B4A596870FEDCBA9 /* sentry.options.json */,
 				105040C63B12418DB7A2E56A /* noop-file.swift */,
 				F6B72321766C4777B9B8F4E7 /* BookShelfAI-Bridging-Header.h */,
 			);
@@ -205,6 +208,7 @@
 				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
 				3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */,
 				D7A7F0290DD646D1801C9C00 /* PrivacyInfo.xcprivacy in Resources */,
+				E1A2B3C4D5E6F708A9B0C1D2 /* sentry.options.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/frontend/ios/BookShelfAI/AppDelegate.mm
+++ b/frontend/ios/BookShelfAI/AppDelegate.mm
@@ -2,11 +2,17 @@
 
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTLinkingManager.h>
+#import <RNSentry/RNSentrySDK.h>
 
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
+  // Initialise native Sentry BEFORE the React Native bridge starts so that
+  // crashes during JS bundle loading / module evaluation are captured.
+  // Configuration is read from sentry.options.json bundled as an app resource.
+  [RNSentrySDK start];
+
   self.moduleName = @"main";
 
   // You can add your custom initial props in the dictionary below.

--- a/frontend/ios/BookShelfAI/sentry.options.json
+++ b/frontend/ios/BookShelfAI/sentry.options.json
@@ -1,0 +1,7 @@
+{
+  "dsn": "https://8d7985b74e3df0be133eb2d78d27a8c3@o4511129011093504.ingest.us.sentry.io/4511129213927424",
+  "environment": "production",
+  "tracesSampleRate": 0.2,
+  "sendDefaultPii": false,
+  "enableAutoSessionTracking": true
+}

--- a/frontend/src/i18n/i18n.ts
+++ b/frontend/src/i18n/i18n.ts
@@ -175,6 +175,8 @@ export const i18nReady = i18n
     react: {
       useSuspense: false,
     },
-  });
+  })
+  // Prevent unhandled promise rejection — fatal in React Native.
+  .catch((err: unknown) => console.error('[i18n] init failed:', err));
 
 export default i18n;


### PR DESCRIPTION
## Summary
- **Native Sentry init:** Call `[RNSentrySDK start]` in `AppDelegate.mm` *before* the RN bridge starts, reading DSN from a bundled `sentry.options.json`. This ensures the native crash reporter is active during JS bundle loading — future crashes will be captured with full error messages in Sentry.
- **Catch i18n promise:** `i18n.init()` returned an uncaught promise (`i18nReady`). Unhandled promise rejections are **fatal in React Native**, matching the exact `RCTFatal → SIGABRT` crash pattern. Added `.catch()` handler.

## Files changed
| File | Change |
|---|---|
| `ios/BookShelfAI/AppDelegate.mm` | Import `RNSentrySDK.h`, call `[RNSentrySDK start]` before bridge init |
| `ios/BookShelfAI/sentry.options.json` | New — DSN + config for native SDK init |
| `ios/BookShelfAI.xcodeproj/project.pbxproj` | Add `sentry.options.json` as bundle resource |
| `src/i18n/i18n.ts` | Add `.catch()` on `i18nReady` promise |

## Test plan
- [x] All 147 frontend tests pass
- [ ] Trigger Xcode Cloud build and verify it compiles with native Sentry init
- [ ] Verify the app no longer crashes at startup on TestFlight
- [ ] If a crash still occurs, check Sentry dashboard — native init should now capture and report the error with full JS stack trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)