### PR TITLE
fix(ios): prevent Sentry dual-init crash on startup

### DIFF
--- a/frontend/ios/BookShelfAI/AppDelegate.mm
+++ b/frontend/ios/BookShelfAI/AppDelegate.mm
@@ -11,7 +11,13 @@
   // Initialise native Sentry BEFORE the React Native bridge starts so that
   // crashes during JS bundle loading / module evaluation are captured.
   // Configuration is read from sentry.options.json bundled as an app resource.
-  [RNSentrySDK start];
+  // Wrapped in @try/@catch so a misconfigured or missing SDK can never
+  // prevent the app from launching.
+  @try {
+    [RNSentrySDK start];
+  } @catch (NSException *exception) {
+    NSLog(@"[Sentry] native init failed: %@", exception);
+  }
 
   self.moduleName = @"main";
 

--- a/frontend/lib/sentry.ts
+++ b/frontend/lib/sentry.ts
@@ -3,8 +3,12 @@ import * as Sentry from '@sentry/react-native';
 const DSN = process.env.EXPO_PUBLIC_SENTRY_DSN;
 
 /**
- * Initialise Sentry.  Safe to call more than once — subsequent calls are
- * no-ops because the SDK ignores re-initialisation.
+ * Initialise the JS layer of Sentry.
+ *
+ * On iOS the native SDK is already started in AppDelegate.mm via
+ * [RNSentrySDK start] (reading sentry.options.json).  The JS init()
+ * call configures the JS-side scope/transport and is safe to call even
+ * when the native layer is already running.
  *
  * Wrapped in try/catch so a native-module error during init can never
  * escalate to RCTFatal and crash the app before anything renders.
@@ -16,10 +20,13 @@ export function initSentry(): void {
     Sentry.init({
       dsn: DSN,
       environment: process.env.EXPO_PUBLIC_ENVIRONMENT ?? 'development',
-      // Capture 20% of transactions in production to keep quota manageable
       tracesSampleRate: process.env.EXPO_PUBLIC_ENVIRONMENT === 'production' ? 0.2 : 1.0,
       sendDefaultPii: false,
       enabled: !!DSN,
+      // Skip native SDK init — already handled by [RNSentrySDK start] in
+      // AppDelegate.mm.  Re-initialising the native layer causes RCTFatal
+      // due to duplicate observer registrations.
+      autoInitializeNativeSdk: false,
     });
   } catch (e) {
     // Log but never crash — the app must boot even if Sentry is broken.


### PR DESCRIPTION
## Summary
- Crash analysis from TestFlight build 27 shows `RCTFatal → SIGABRT` ~250ms after launch
- Root cause: `[RNSentrySDK start]` in AppDelegate.mm initializes the native Sentry SDK, then `Sentry.init()` in JS re-initializes it, causing duplicate observer registrations that trigger `RCTFatal`
- Added `autoInitializeNativeSdk: false` to JS `Sentry.init()` so it only configures JS-side scope/transport
- Wrapped `[RNSentrySDK start]` in `@try/@catch` so native SDK failures can never prevent app launch

## Test plan
- [ ] Build and deploy to TestFlight — app should launch without crash
- [ ] Verify Sentry events still appear in dashboard (native + JS layers)
- [ ] Trigger a test crash to confirm reporting works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)