### PR TITLE
fix(ios): disable fmt consteval to fix Xcode build failure

### DIFF
--- a/frontend/ios/Podfile
+++ b/frontend/ios/Podfile
@@ -57,6 +57,18 @@ target 'BookShelfAI' do
       :ccache_enabled => podfile_properties['apple.ccacheEnabled'] == 'true',
     )
 
+    # Fix fmt 9.1.0 consteval compilation error with newer Apple Clang.
+    # Apple Clang advertises __cpp_consteval but has bugs evaluating
+    # consteval expressions, causing build failures in format-inl.h.
+    installer.pods_project.targets.each do |target|
+      if target.name == 'fmt'
+        target.build_configurations.each do |config|
+          config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)']
+          config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'FMT_CONSTEVAL='
+        end
+      end
+    end
+
     # This is necessary for Xcode 14, because it signs resource bundles by default
     # when building for devices.
     installer.target_installation_results.pod_target_installation_results


### PR DESCRIPTION
## Summary
- Fixes Xcode Cloud build failure caused by `consteval` compilation errors in fmt 9.1.0's `format-inl.h`
- Apple Clang advertises `__cpp_consteval` support but has bugs evaluating consteval expressions, so we define `FMT_CONSTEVAL=` (empty) on the fmt pod target to bypass it
- No `pod install` needed locally — `ci_post_clone.sh` already regenerates `Podfile.lock` during Xcode Cloud builds

## Test plan
- [ ] Xcode Cloud build passes (Build 35+)
- [ ] App launches and runs normally on iOS device/simulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)