### PR TITLE
fix(ios): stop deleting Podfile.lock in CI to prevent pod version drift

### DIFF
--- a/frontend/ios/ci_scripts/ci_post_clone.sh
+++ b/frontend/ios/ci_scripts/ci_post_clone.sh
@@ -44,8 +44,8 @@ retry 3 10 npm ci
 
 # Install CocoaPods dependencies
 cd ios
-# Remove stale Podfile.lock — it was generated with an older react-native version
-# and the fmt/hermes-engine checksums no longer match RN 0.83.
-# pod install will regenerate a correct lock file.
-rm -f Podfile.lock
+# NOTE: Podfile.lock is committed and up-to-date (regenerated in a54d09b for RN 0.83).
+# Do NOT delete it — using the committed lock ensures reproducible pod versions across
+# CI builds and prevents Hermes/React-Native runtime drift that can cause
+# handleBundleLoadingError crashes at launch.
 retry 3 30 pod install


### PR DESCRIPTION
## Problem

TestFlight build 38 (2026-03-31) crashes immediately on launch with:

```
RCTFatal → RCTInstance handleBundleLoadingError (RCTInstance.mm:528)
```

App uptime: `null` — crashed before any JS executed.

## Root Cause

`ci_post_clone.sh` deletes `Podfile.lock` before every `pod install`:

```bash
rm -f Podfile.lock   # ← the culprit
pod install
```

This was originally added because the lock was stale (generated against an older RN version with mismatched `fmt`/`hermes-engine` checksums). That was fixed in `a54d09b` which ran a fresh `pod install` on a clean Mac and committed the correct lock.

With the `rm` still in place, every Xcode Cloud build resolves pods from scratch. If CocoaPods resolves a different Hermes version or React Native runtime pod between builds, the native runtime can diverge from the embedded JS bundle — triggering `handleBundleLoadingError` at launch.

## Fix

Remove the `rm -f Podfile.lock` line. The committed lock is now correct and pins all pod versions. Reproducible pod resolution prevents runtime drift.

## Investigation notes

- `package-lock.json` correctly pins `@sentry/react-native@8.6.0` — CI installs the right version via `npm ci`.
- Local `node_modules` has v7.11.0 (a dev-machine-only drift, no CI impact). Run `npm ci` locally to fix.
- `.xcode.env` already sets `SENTRY_ALLOW_FAILURE=true` so Sentry source-map uploads can't fail the build.
- The AppDelegate `[super ...]` crash (fixed in `6a2770d`) is a separate issue — those methods only fire on URL-scheme / Universal Link opens, not on normal launch.

## Test plan

- [ ] Trigger a new Xcode Cloud build from this branch and verify it completes without deleting the lock
- [ ] Confirm the installed pod versions match the committed `Podfile.lock`
- [ ] Install the resulting TestFlight build and verify no launch crash
- [ ] Run locally: `npm ci && cd ios && pod install` (should use the committed lock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)