### PR TITLE
fix(ios): persist NODE_BINARY for Xcode Cloud build phases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ frontend/ios/build/
 frontend/ios/DerivedData/
 frontend/ios/*.xcarchive
 frontend/ios/Bookshelf.xcworkspace/xcuserdata/
+frontend/ios/.xcode.env.local

--- a/frontend/ios/ci_scripts/ci_post_clone.sh
+++ b/frontend/ios/ci_scripts/ci_post_clone.sh
@@ -38,6 +38,16 @@ retry() {
 brew install node@22
 export PATH="$(brew --prefix node@22)/bin:$PATH"
 
+# Persist NODE_BINARY for Xcode build phases (which run in separate processes).
+# Without this, .xcode.env falls back to `command -v node` which returns empty
+# on Xcode Cloud (node@22 is keg-only and not on the default PATH).
+# An empty NODE_BINARY causes the "Bundle React Native code" phase to fail
+# silently (masked by SENTRY_ALLOW_FAILURE=true), producing an archive
+# without main.jsbundle → handleBundleLoadingError crash at launch.
+NODE22_BIN="$(brew --prefix node@22)/bin/node"
+echo "export NODE_BINARY=\"$NODE22_BIN\"" > "$CI_PRIMARY_REPOSITORY_PATH/frontend/ios/.xcode.env.local"
+echo "INFO: wrote .xcode.env.local → NODE_BINARY=$NODE22_BIN"
+
 # Install Node.js dependencies (required for React Native pod scripts)
 cd "$CI_PRIMARY_REPOSITORY_PATH/frontend"
 retry 3 10 npm ci


### PR DESCRIPTION
## Summary
- **Root cause:** `ci_post_clone.sh` installs Node 22 and sets PATH, but that PATH only lives in the clone script's process. Xcode build phases run in separate processes where `node@22` (keg-only) isn't on the default PATH, so `NODE_BINARY=$(command -v node)` resolves to empty string.
- The Sentry wrapper's `SENTRY_ALLOW_FAILURE=true` masks the entire bundling failure, producing an archive **without `main.jsbundle`** → `handleBundleLoadingError` crash on launch (TestFlight build 39).
- Fix: `ci_post_clone.sh` now writes `.xcode.env.local` with the explicit Node 22 binary path so build phases can find it.

## Test plan
- [ ] Trigger a new Xcode Cloud build and verify `main.jsbundle` is present in the archive
- [ ] Install the resulting TestFlight build and confirm it launches without crashing
- [ ] Verify Xcode Cloud build logs show `INFO: wrote .xcode.env.local` message

🤖 Generated with [Claude Code](https://claude.com/claude-code)