### PR TITLE
feat(tests): close coverage gaps — backend 99%, frontend 95%

### DIFF
--- a/backend/tests/unit/test_config.py
+++ b/backend/tests/unit/test_config.py
@@ -30,6 +30,32 @@ def test_allowed_emails_list_empty():
     assert s.allowed_emails_list == []
 
 
+class TestGoogleClientIds:
+    def test_returns_all_configured_ids(self):
+        s = Settings(
+            database_url="postgresql+asyncpg://u:p@localhost/db",
+            google_client_id="web-id",
+            google_ios_client_id="ios-id",
+            google_android_client_id="android-id",
+        )
+        assert s.google_client_ids == ["web-id", "ios-id", "android-id"]
+
+    def test_excludes_empty_ids(self):
+        s = Settings(
+            database_url="postgresql+asyncpg://u:p@localhost/db",
+            google_client_id="web-id",
+            google_ios_client_id="",
+            google_android_client_id="",
+        )
+        assert s.google_client_ids == ["web-id"]
+
+    def test_returns_empty_when_none_set(self):
+        s = Settings(
+            database_url="postgresql+asyncpg://u:p@localhost/db",
+        )
+        assert s.google_client_ids == []
+
+
 class TestCorsOriginsValidator:
     def test_accepts_valid_origins(self):
         s = Settings(

--- a/backend/tests/unit/test_file_validation.py
+++ b/backend/tests/unit/test_file_validation.py
@@ -1,0 +1,92 @@
+"""Unit tests for validate_magic_bytes — covers all file type branches."""
+
+import pytest
+
+from app.core.file_validation import validate_magic_bytes
+
+
+class TestValidateMagicBytes:
+    # ── JPEG ─────────────────────────────────────────────────────────────────
+
+    def test_valid_jpeg(self):
+        data = b"\xff\xd8\xff\xe0" + b"\x00" * 100
+        assert validate_magic_bytes(".jpg", data) is True
+
+    def test_valid_jpeg_alt_ext(self):
+        data = b"\xff\xd8\xff\xe1" + b"\x00" * 100
+        assert validate_magic_bytes(".jpeg", data) is True
+
+    def test_invalid_jpeg_wrong_magic(self):
+        data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+        assert validate_magic_bytes(".jpg", data) is False
+
+    # ── PNG ──────────────────────────────────────────────────────────────────
+
+    def test_valid_png(self):
+        data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+        assert validate_magic_bytes(".png", data) is True
+
+    def test_invalid_png_wrong_magic(self):
+        data = b"\xff\xd8\xff\xe0" + b"\x00" * 100
+        assert validate_magic_bytes(".png", data) is False
+
+    # ── WebP ─────────────────────────────────────────────────────────────────
+
+    def test_valid_webp(self):
+        # RIFF....WEBP
+        data = b"RIFF\x00\x00\x00\x00WEBP" + b"\x00" * 100
+        assert validate_magic_bytes(".webp", data) is True
+
+    def test_webp_missing_webp_marker(self):
+        data = b"RIFF\x00\x00\x00\x00NOPE" + b"\x00" * 100
+        assert validate_magic_bytes(".webp", data) is False
+
+    def test_webp_too_short_for_webp_marker(self):
+        # RIFF header present but data < 12 bytes
+        data = b"RIFF\x00\x00\x00\x00WEB"
+        assert validate_magic_bytes(".webp", data) is False
+
+    def test_webp_wrong_prefix(self):
+        data = b"NOPE\x00\x00\x00\x00WEBP"
+        assert validate_magic_bytes(".webp", data) is False
+
+    # ── HEIC/HEIF ────────────────────────────────────────────────────────────
+
+    def test_valid_heic(self):
+        # 4-byte size | "ftyp" | brand
+        data = b"\x00\x00\x00\x18ftypheic" + b"\x00" * 100
+        assert validate_magic_bytes(".heic", data) is True
+
+    def test_valid_heif(self):
+        data = b"\x00\x00\x00\x18ftypmif1" + b"\x00" * 100
+        assert validate_magic_bytes(".heif", data) is True
+
+    @pytest.mark.parametrize("brand", [b"heic", b"heix", b"mif1", b"msf1", b"hevc", b"hevx"])
+    def test_heic_all_valid_brands(self, brand):
+        data = b"\x00\x00\x00\x18ftyp" + brand + b"\x00" * 100
+        assert validate_magic_bytes(".heic", data) is True
+
+    def test_heic_invalid_brand(self):
+        data = b"\x00\x00\x00\x18ftypxxxx" + b"\x00" * 100
+        assert validate_magic_bytes(".heic", data) is False
+
+    def test_heic_missing_ftyp(self):
+        data = b"\x00\x00\x00\x18NOPEheic" + b"\x00" * 100
+        assert validate_magic_bytes(".heic", data) is False
+
+    def test_heic_too_short(self):
+        # HEIC needs at least 12 bytes
+        data = b"\x00\x00\x00\x18ftyp"  # only 8 bytes
+        assert validate_magic_bytes(".heic", data) is False
+
+    # ── Edge cases ───────────────────────────────────────────────────────────
+
+    def test_data_too_short(self):
+        assert validate_magic_bytes(".jpg", b"\xff\xd8") is False
+
+    def test_empty_data(self):
+        assert validate_magic_bytes(".jpg", b"") is False
+
+    def test_unknown_extension(self):
+        data = b"\x00" * 100
+        assert validate_magic_bytes(".bmp", data) is False

--- a/backend/tests/unit/test_file_validation.py
+++ b/backend/tests/unit/test_file_validation.py
@@ -61,7 +61,9 @@ class TestValidateMagicBytes:
         data = b"\x00\x00\x00\x18ftypmif1" + b"\x00" * 100
         assert validate_magic_bytes(".heif", data) is True
 
-    @pytest.mark.parametrize("brand", [b"heic", b"heix", b"mif1", b"msf1", b"hevc", b"hevx"])
+    @pytest.mark.parametrize(
+        "brand", [b"heic", b"heix", b"mif1", b"msf1", b"hevc", b"hevx"]
+    )
     def test_heic_all_valid_brands(self, brand):
         data = b"\x00\x00\x00\x18ftyp" + brand + b"\x00" * 100
         assert validate_magic_bytes(".heic", data) is True

--- a/backend/tests/unit/test_verify_turnstile.py
+++ b/backend/tests/unit/test_verify_turnstile.py
@@ -3,7 +3,6 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
-import pytest
 
 from app.api.scan import _verify_turnstile
 

--- a/backend/tests/unit/test_verify_turnstile.py
+++ b/backend/tests/unit/test_verify_turnstile.py
@@ -1,0 +1,90 @@
+"""Unit tests for _verify_turnstile — exercises the function body directly."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from app.api.scan import _verify_turnstile
+
+
+class TestVerifyTurnstile:
+    async def test_returns_true_on_success(self):
+        resp = MagicMock()
+        resp.json.return_value = {"success": True}
+        resp.raise_for_status = MagicMock()
+
+        client = AsyncMock()
+        client.post = AsyncMock(return_value=resp)
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.api.scan.httpx.AsyncClient", return_value=client):
+            result = await _verify_turnstile("valid-token")
+
+        assert result is True
+
+    async def test_returns_false_on_failure(self):
+        resp = MagicMock()
+        resp.json.return_value = {"success": False}
+        resp.raise_for_status = MagicMock()
+
+        client = AsyncMock()
+        client.post = AsyncMock(return_value=resp)
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.api.scan.httpx.AsyncClient", return_value=client):
+            result = await _verify_turnstile("bad-token")
+
+        assert result is False
+
+    async def test_returns_false_on_timeout(self):
+        client = AsyncMock()
+        client.post = AsyncMock(side_effect=httpx.TimeoutException("timed out"))
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.api.scan.httpx.AsyncClient", return_value=client):
+            result = await _verify_turnstile("any-token")
+
+        assert result is False
+
+    async def test_returns_false_on_http_error(self):
+        client = AsyncMock()
+        client.post = AsyncMock(
+            side_effect=httpx.HTTPStatusError(
+                "server error",
+                request=MagicMock(),
+                response=MagicMock(status_code=500),
+            )
+        )
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.api.scan.httpx.AsyncClient", return_value=client):
+            result = await _verify_turnstile("any-token")
+
+        assert result is False
+
+    async def test_posts_correct_payload(self):
+        resp = MagicMock()
+        resp.json.return_value = {"success": True}
+        resp.raise_for_status = MagicMock()
+
+        client = AsyncMock()
+        client.post = AsyncMock(return_value=resp)
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("app.api.scan.httpx.AsyncClient", return_value=client),
+            patch("app.api.scan.settings") as mock_settings,
+        ):
+            mock_settings.turnstile_secret_key = "test-secret"
+            await _verify_turnstile("user-token")
+
+        client.post.assert_awaited_once()
+        _, kwargs = client.post.call_args
+        assert kwargs["data"]["secret"] == "test-secret"
+        assert kwargs["data"]["response"] == "user-token"

--- a/frontend/__tests__/unit/IndexScreen.test.tsx
+++ b/frontend/__tests__/unit/IndexScreen.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react-native';
+
+import Index from '../../app/index';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockUseAuth = jest.fn();
+jest.mock('../../hooks/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+jest.mock('expo-router', () => ({
+  Redirect: ({ href }: { href: string }) => {
+    const { Text } = require('react-native');
+    return <Text testID="redirect">{href}</Text>;
+  },
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('Index (root redirect)', () => {
+  it('shows loading indicator while auth state resolves', () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: false, isLoading: true });
+    const { queryByTestId, UNSAFE_queryByType } = render(<Index />);
+    // Should NOT redirect while loading
+    expect(queryByTestId('redirect')).toBeNull();
+  });
+
+  it('redirects to my-books when authenticated', async () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: true, isLoading: false });
+    const { getByTestId } = render(<Index />);
+    expect(getByTestId('redirect').props.children).toBe('/(tabs)/my-books');
+  });
+
+  it('redirects to login when not authenticated', async () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: false, isLoading: false });
+    const { getByTestId } = render(<Index />);
+    expect(getByTestId('redirect').props.children).toBe('/(auth)/login');
+  });
+});

--- a/frontend/__tests__/unit/LoginScreen.test.tsx
+++ b/frontend/__tests__/unit/LoginScreen.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Alert } from 'react-native';
 import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 
 import LoginScreen from '../../app/(auth)/login';
@@ -110,14 +111,16 @@ describe('LoginScreen', () => {
     await waitFor(() => expect(mockLogin).not.toHaveBeenCalled());
   });
 
-  it('logs error when login fails', async () => {
-    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  it('shows error alert when login fails', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
     setupGoogleAuth({
       response: { type: 'success', params: { id_token: 'bad-token' } },
     });
     mockLogin.mockRejectedValue(new Error('401 Unauthorized'));
     render(<LoginScreen />);
-    await waitFor(() => expect(spy).toHaveBeenCalled());
-    spy.mockRestore();
+    await waitFor(() =>
+      expect(alertSpy).toHaveBeenCalledWith('Error', 'Sign-in failed. Please try again.')
+    );
+    alertSpy.mockRestore();
   });
 });

--- a/frontend/__tests__/unit/LoginScreen.test.tsx
+++ b/frontend/__tests__/unit/LoginScreen.test.tsx
@@ -109,4 +109,15 @@ describe('LoginScreen', () => {
     render(<LoginScreen />);
     await waitFor(() => expect(mockLogin).not.toHaveBeenCalled());
   });
+
+  it('logs error when login fails', async () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    setupGoogleAuth({
+      response: { type: 'success', params: { id_token: 'bad-token' } },
+    });
+    mockLogin.mockRejectedValue(new Error('401 Unauthorized'));
+    render(<LoginScreen />);
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+    spy.mockRestore();
+  });
 });

--- a/frontend/__tests__/unit/TabLayout.test.tsx
+++ b/frontend/__tests__/unit/TabLayout.test.tsx
@@ -25,7 +25,13 @@ jest.mock('expo-router', () => {
   const React = require('react');
   const { View, Text } = require('react-native');
 
-  function MockTabs({ children, screenOptions }: { children: React.ReactNode; screenOptions: Record<string, unknown> }) {
+  function MockTabs({
+    children,
+    screenOptions,
+  }: {
+    children: React.ReactNode;
+    screenOptions: Record<string, unknown>;
+  }) {
     return (
       <View testID="tabs-container" accessibilityHint={JSON.stringify(screenOptions)}>
         {children}
@@ -36,9 +42,10 @@ jest.mock('expo-router', () => {
   function MockScreen(props: { name: string; options: Record<string, unknown> }) {
     mockScreenProps.push({ name: props.name, options: props.options });
     // Invoke tabBarIcon to exercise the icon render callback
-    const icon = typeof props.options?.tabBarIcon === 'function'
-      ? props.options.tabBarIcon({ color: '#000', size: 24 })
-      : null;
+    const icon =
+      typeof props.options?.tabBarIcon === 'function'
+        ? props.options.tabBarIcon({ color: '#000', size: 24 })
+        : null;
     return (
       <View testID={`tab-${props.name}`}>
         <Text>{props.options?.title as string}</Text>

--- a/frontend/__tests__/unit/TabLayout.test.tsx
+++ b/frontend/__tests__/unit/TabLayout.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+import TabLayout from '../../app/(tabs)/_layout';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+jest.mock('../../hooks/useTheme', () => ({
+  useTheme: () => ({
+    theme: {
+      colors: {
+        iconActive: '#2563EB',
+        iconInactive: '#9CA3AF',
+        surface: '#FFFFFF',
+        text: '#111827',
+      },
+    },
+  }),
+}));
+
+// Capture Tabs.Screen props for assertion
+const mockScreenProps: Array<{ name: string; options: Record<string, unknown> }> = [];
+
+jest.mock('expo-router', () => {
+  const React = require('react');
+  const { View, Text } = require('react-native');
+
+  function MockTabs({ children, screenOptions }: { children: React.ReactNode; screenOptions: Record<string, unknown> }) {
+    return (
+      <View testID="tabs-container" accessibilityHint={JSON.stringify(screenOptions)}>
+        {children}
+      </View>
+    );
+  }
+
+  function MockScreen(props: { name: string; options: Record<string, unknown> }) {
+    mockScreenProps.push({ name: props.name, options: props.options });
+    // Invoke tabBarIcon to exercise the icon render callback
+    const icon = typeof props.options?.tabBarIcon === 'function'
+      ? props.options.tabBarIcon({ color: '#000', size: 24 })
+      : null;
+    return (
+      <View testID={`tab-${props.name}`}>
+        <Text>{props.options?.title as string}</Text>
+        {icon}
+      </View>
+    );
+  }
+
+  MockTabs.Screen = MockScreen;
+  return { Tabs: MockTabs };
+});
+
+jest.mock('@expo/vector-icons', () => {
+  const { Text } = require('react-native');
+  return {
+    Ionicons: ({ name, size, color }: { name: string; size: number; color: string }) => (
+      <Text testID={`icon-${name}`}>{name}</Text>
+    ),
+  };
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockScreenProps.length = 0;
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('TabLayout', () => {
+  it('renders 4 tab screens', () => {
+    render(<TabLayout />);
+    expect(mockScreenProps).toHaveLength(4);
+  });
+
+  it('includes scan, wishlist, my-books, and settings tabs', () => {
+    render(<TabLayout />);
+    const names = mockScreenProps.map((s) => s.name);
+    expect(names).toEqual(['scan', 'wishlist', 'my-books', 'settings']);
+  });
+
+  it('tab titles use i18n keys', () => {
+    render(<TabLayout />);
+    const titles = mockScreenProps.map((s) => s.options.title);
+    // react-i18next mock returns the key itself
+    expect(titles).toEqual(['Scan', 'Wishlist', 'My Books', 'Settings']);
+  });
+
+  it('applies theme colors to tab bar via screenOptions', () => {
+    const { getByTestId } = render(<TabLayout />);
+    const container = getByTestId('tabs-container');
+    const screenOptions = JSON.parse(container.props.accessibilityHint);
+    expect(screenOptions.tabBarActiveTintColor).toBe('#2563EB');
+    expect(screenOptions.tabBarInactiveTintColor).toBe('#9CA3AF');
+    expect(screenOptions.tabBarStyle.backgroundColor).toBe('#FFFFFF');
+  });
+});


### PR DESCRIPTION
## Summary
- **Backend** (98% → 99%): Added unit tests for `validate_magic_bytes` (HEIC/HEIF, WebP, edge cases) and `_verify_turnstile` function body (success, failure, timeout, HTTP error)
- **Frontend** (91% → 95% lines): Added tests for `app/index.tsx` root redirect (0% → 100%), `app/(tabs)/_layout.tsx` tab layout (0% → 100%), and `login.tsx` error handling (92% → 100%)

## New files
- `backend/tests/unit/test_file_validation.py` — 23 tests
- `backend/tests/unit/test_verify_turnstile.py` — 5 tests
- `frontend/__tests__/unit/IndexScreen.test.tsx` — 3 tests
- `frontend/__tests__/unit/TabLayout.test.tsx` — 4 tests

## Test plan
- [x] `cd backend && pytest tests/ --cov=app` — 313 passed, 99% coverage
- [x] `cd frontend && npx jest --coverage` — 163 passed, 95.39% line coverage
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)