### PR TITLE
ci: add ZAP weekly security scan

### DIFF
--- a/.github/workflows/zap-scan.yml
+++ b/.github/workflows/zap-scan.yml
@@ -1,0 +1,15 @@
+name: ZAP Weekly Scan
+
+on:
+  schedule:
+    # Weekly Sunday at 06:00 UTC (midnight Mountain Time)
+    - cron: '0 6 * * 0'
+  workflow_dispatch:
+
+jobs:
+  zap-scan:
+    uses: wcmchenry3-stack/.github/.github/workflows/called-zap-scheduled.yml@main
+    with:
+      target-url: ${{ secrets.SITE_URL }}
+      artifact-name: 'zap-weekly-bookshelf'
+    secrets: inherit


### PR DESCRIPTION
Adds a weekly OWASP ZAP baseline scan workflow, matching the reusable workflow pattern used across the org. Runs every Sunday at 06:00 UTC via schedule and supports manual dispatch.