### PR TITLE
feat(scan): background book search with offline queue and retry

### DIFF
--- a/frontend/__tests__/unit/InAppBanner.test.tsx
+++ b/frontend/__tests__/unit/InAppBanner.test.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { act, fireEvent, render } from '@testing-library/react-native';
+
+import { InAppBanner } from '../../components/InAppBanner';
+import { BannerProvider } from '../../contexts/BannerContext';
+import { useBanner } from '../../hooks/useBanner';
+import { Pressable, Text } from 'react-native';
+
+jest.mock('../../hooks/useTheme', () => ({
+  useTheme: () => ({
+    theme: {
+      colors: {
+        background: '#fff',
+        surface: '#f5f5f5',
+        border: '#ccc',
+        text: '#000',
+        textSecondary: '#888',
+        primary: '#007AFF',
+        success: '#16A34A',
+        error: '#DC2626',
+      },
+      typography: { fontSizeBase: 16 },
+    },
+  }),
+}));
+
+function BannerTrigger({
+  message,
+  type,
+  actions,
+}: {
+  message: string;
+  type: 'success' | 'error' | 'info';
+  actions?: { label: string; onPress: () => void }[];
+}) {
+  const { showBanner } = useBanner();
+  return (
+    <Pressable
+      testID="trigger"
+      onPress={() => showBanner({ message, type, actions, duration: 10000 })}
+    >
+      <Text>Show</Text>
+    </Pressable>
+  );
+}
+
+function renderWithBanner(triggerProps: {
+  message: string;
+  type: 'success' | 'error' | 'info';
+  actions?: { label: string; onPress: () => void }[];
+}) {
+  return render(
+    <BannerProvider>
+      <InAppBanner />
+      <BannerTrigger {...triggerProps} />
+    </BannerProvider>
+  );
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('InAppBanner', () => {
+  it('renders nothing when no banner is shown', () => {
+    const { queryByRole } = render(
+      <BannerProvider>
+        <InAppBanner />
+      </BannerProvider>
+    );
+    expect(queryByRole('alert')).toBeNull();
+  });
+
+  it('renders message text when banner is triggered', () => {
+    const { getByTestId, getByText } = renderWithBanner({
+      message: 'Book found!',
+      type: 'success',
+    });
+    fireEvent.press(getByTestId('trigger'));
+    expect(getByText('Book found!')).toBeTruthy();
+  });
+
+  it('renders action buttons when provided', () => {
+    const onPress = jest.fn();
+    const { getByTestId, getByLabelText } = renderWithBanner({
+      message: 'Scan failed',
+      type: 'error',
+      actions: [{ label: 'Retry', onPress }],
+    });
+    fireEvent.press(getByTestId('trigger'));
+    const retryBtn = getByLabelText('Retry');
+    expect(retryBtn).toBeTruthy();
+  });
+
+  it('calls action onPress when action button is tapped', () => {
+    const onPress = jest.fn();
+    const { getByTestId, getByLabelText } = renderWithBanner({
+      message: 'Scan failed',
+      type: 'error',
+      actions: [{ label: 'Retry', onPress }],
+    });
+    fireEvent.press(getByTestId('trigger'));
+    fireEvent.press(getByLabelText('Retry'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('auto-dismisses after duration', () => {
+    const { getByTestId, getByText, queryByText } = renderWithBanner({
+      message: 'Done!',
+      type: 'success',
+    });
+    fireEvent.press(getByTestId('trigger'));
+    expect(getByText('Done!')).toBeTruthy();
+
+    // Advance past default + slide-out animation
+    act(() => {
+      jest.advanceTimersByTime(10000 + 500);
+    });
+    expect(queryByText('Done!')).toBeNull();
+  });
+
+  it('dismisses on tap', () => {
+    const { getByTestId, getByText, queryByText } = renderWithBanner({
+      message: 'Tap to dismiss',
+      type: 'info',
+    });
+    fireEvent.press(getByTestId('trigger'));
+    expect(getByText('Tap to dismiss')).toBeTruthy();
+
+    // Tap the banner content to dismiss
+    fireEvent.press(getByText('Tap to dismiss'));
+
+    // After slide-out animation
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    expect(queryByText('Tap to dismiss')).toBeNull();
+  });
+});

--- a/frontend/__tests__/unit/ScanJobContext.test.tsx
+++ b/frontend/__tests__/unit/ScanJobContext.test.tsx
@@ -1,0 +1,362 @@
+import React from 'react';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+
+import { ScanJobProvider } from '../../contexts/ScanJobContext';
+import { BannerProvider } from '../../contexts/BannerContext';
+import { useScanJobs } from '../../hooks/useScanJobs';
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockPost = jest.fn();
+const mockGet = jest.fn();
+
+jest.mock('../../lib/api', () => ({
+  api: {
+    post: (...args: unknown[]) => mockPost(...args),
+    get: (...args: unknown[]) => mockGet(...args),
+  },
+}));
+
+const mockLoadJobs = jest.fn().mockResolvedValue([]);
+const mockSaveJobs = jest.fn();
+const mockClearJobs = jest.fn();
+
+jest.mock('../../lib/scanJobStorage', () => ({
+  loadJobs: (...args: unknown[]) => mockLoadJobs(...args),
+  saveJobs: (...args: unknown[]) => mockSaveJobs(...args),
+  clearJobs: (...args: unknown[]) => mockClearJobs(...args),
+}));
+
+const mockNetInfoFetch = jest.fn().mockResolvedValue({ isConnected: true });
+const mockNetInfoAddEventListener = jest.fn().mockReturnValue(() => {});
+
+jest.mock('@react-native-community/netinfo', () => ({
+  __esModule: true,
+  default: {
+    fetch: () => mockNetInfoFetch(),
+    addEventListener: (cb: unknown) => mockNetInfoAddEventListener(cb),
+  },
+}));
+
+let mockUuidCounter = 0;
+jest.mock('uuid', () => ({
+  v4: () => `test-uuid-${++mockUuidCounter}`,
+}));
+
+jest.mock('expo-file-system', () => ({
+  deleteAsync: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../hooks/useTheme', () => ({
+  useTheme: () => ({
+    theme: {
+      colors: {
+        background: '#fff',
+        surface: '#f5f5f5',
+        border: '#ccc',
+        text: '#000',
+        textSecondary: '#888',
+        primary: '#007AFF',
+        success: '#16A34A',
+        error: '#DC2626',
+      },
+      typography: { fontSizeBase: 16 },
+    },
+  }),
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <BannerProvider>
+      <ScanJobProvider>{children}</ScanJobProvider>
+    </BannerProvider>
+  );
+}
+
+async function renderScanJobs() {
+  const hook = renderHook(() => useScanJobs(), { wrapper });
+  // Wait for mount effect (loadJobs) to complete and state to settle.
+  await waitFor(() => {
+    expect(mockSaveJobs).toHaveBeenCalled();
+  });
+  return hook;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  mockUuidCounter = 0;
+  mockLoadJobs.mockResolvedValue([]);
+  mockNetInfoFetch.mockResolvedValue({ isConnected: true });
+  mockNetInfoAddEventListener.mockReturnValue(() => {});
+  mockSaveJobs.mockResolvedValue(undefined);
+});
+
+describe('ScanJobContext — startScan', () => {
+  it('creates a job and fires text search API call', async () => {
+    mockGet.mockResolvedValueOnce({ data: [{ title: 'Dune', author: 'Herbert' }] });
+    const { result } = await renderScanJobs();
+
+    await act(async () => {
+      await result.current.startScan('text', undefined, 'Dune');
+    });
+
+    const job = result.current.jobs.find((j) => j.type === 'text');
+    expect(job).toBeTruthy();
+    expect(job?.status).toBe('complete');
+    expect(job?.results).toHaveLength(1);
+    expect(mockGet).toHaveBeenCalledWith('/books/search', { params: { q: 'Dune' } });
+  });
+
+  it('creates a job and fires image scan API call', async () => {
+    mockPost.mockResolvedValueOnce({ data: [{ title: 'Dune', author: 'Herbert' }] });
+    const { result } = await renderScanJobs();
+
+    await act(async () => {
+      await result.current.startScan('image', 'file:///docs/scan-queue/photo.jpg');
+    });
+
+    const job = result.current.jobs.find((j) => j.type === 'image');
+    expect(job?.status).toBe('complete');
+    expect(mockPost).toHaveBeenCalledWith('/scan', expect.any(FormData), expect.any(Object));
+  });
+
+  it('sets job status to failed on API error', async () => {
+    mockGet.mockRejectedValueOnce(new Error('network'));
+    const { result } = await renderScanJobs();
+
+    await act(async () => {
+      await result.current.startScan('text', undefined, 'xyz');
+    });
+
+    const job = result.current.jobs[0];
+    expect(job?.status).toBe('failed');
+    expect(job?.error).toBe('network_or_server');
+  });
+
+  it('sets job status to failed when no results returned', async () => {
+    mockGet.mockResolvedValueOnce({ data: [] });
+    const { result } = await renderScanJobs();
+
+    await act(async () => {
+      await result.current.startScan('text', undefined, 'nothing');
+    });
+
+    const job = result.current.jobs[0];
+    expect(job?.status).toBe('failed');
+    expect(job?.error).toBe('no_results');
+  });
+
+  it('queues job when offline', async () => {
+    mockNetInfoFetch.mockResolvedValue({ isConnected: false });
+    const { result } = await renderScanJobs();
+
+    await act(async () => {
+      await result.current.startScan('text', undefined, 'Dune');
+    });
+
+    const job = result.current.jobs[0];
+    expect(job?.status).toBe('queued');
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+});
+
+describe('ScanJobContext — retryScan', () => {
+  it('increments retry count and re-fires with pre-loaded job', async () => {
+    mockLoadJobs.mockResolvedValue([
+      {
+        id: 'retry-job',
+        type: 'text' as const,
+        status: 'failed' as const,
+        createdAt: Date.now(),
+        query: 'Dune',
+        retryCount: 0,
+        error: 'network_or_server',
+      },
+    ]);
+    const { result } = await renderScanJobs();
+    expect(result.current.jobs[0]?.status).toBe('failed');
+
+    mockGet.mockResolvedValueOnce({ data: [{ title: 'Dune', author: 'Herbert' }] });
+    await act(async () => {
+      await result.current.retryScan('retry-job');
+    });
+
+    await waitFor(() => {
+      expect(result.current.jobs[0]?.status).toBe('complete');
+    });
+    expect(result.current.jobs[0]?.retryCount).toBe(1);
+  });
+
+  it('auto-queues when max retries reached', async () => {
+    mockLoadJobs.mockResolvedValue([
+      {
+        id: 'existing-job',
+        type: 'text',
+        status: 'failed',
+        createdAt: Date.now(),
+        query: 'test',
+        retryCount: 3,
+      },
+    ]);
+    const { result } = await renderScanJobs();
+    expect(result.current.jobs).toHaveLength(1);
+
+    await act(async () => {
+      await result.current.retryScan('existing-job');
+    });
+
+    const job = result.current.jobs.find((j) => j.id === 'existing-job');
+    expect(job?.status).toBe('queued');
+  });
+});
+
+describe('ScanJobContext — queueForLater', () => {
+  it('sets job status to queued', async () => {
+    const { result } = await renderScanJobs();
+
+    mockGet.mockRejectedValueOnce(new Error('fail'));
+    await act(async () => {
+      await result.current.startScan('text', undefined, 'Dune');
+    });
+    expect(result.current.jobs[0]?.status).toBe('failed');
+
+    act(() => {
+      result.current.queueForLater(result.current.jobs[0].id);
+    });
+
+    expect(result.current.jobs[0]?.status).toBe('queued');
+  });
+});
+
+describe('ScanJobContext — persistence', () => {
+  it('persists jobs to storage on change', async () => {
+    await renderScanJobs();
+
+    await waitFor(() => {
+      expect(mockSaveJobs).toHaveBeenCalled();
+    });
+  });
+
+  it('loads persisted jobs on mount', async () => {
+    mockLoadJobs.mockResolvedValue([
+      {
+        id: 'persisted-job',
+        type: 'text',
+        status: 'queued',
+        createdAt: Date.now(),
+        query: 'test',
+        retryCount: 0,
+      },
+    ]);
+    const { result } = await renderScanJobs();
+    expect(result.current.jobs).toHaveLength(1);
+    expect(result.current.jobs[0].id).toBe('persisted-job');
+  });
+
+  it('resets interrupted searching jobs to pending on mount', async () => {
+    mockLoadJobs.mockResolvedValue([
+      {
+        id: 'interrupted-job',
+        type: 'text',
+        status: 'searching',
+        createdAt: Date.now(),
+        query: 'test',
+        retryCount: 0,
+      },
+    ]);
+    const { result } = await renderScanJobs();
+    expect(result.current.jobs[0].status).toBe('pending');
+  });
+});
+
+describe('ScanJobContext — dismissJob', () => {
+  it('removes job from list', async () => {
+    const { result } = await renderScanJobs();
+
+    mockGet.mockRejectedValueOnce(new Error('fail'));
+    await act(async () => {
+      await result.current.startScan('text', undefined, 'Dune');
+    });
+    expect(result.current.jobs).toHaveLength(1);
+    const jobId = result.current.jobs[0].id;
+
+    act(() => {
+      result.current.dismissJob(jobId);
+    });
+
+    expect(result.current.jobs).toHaveLength(0);
+  });
+});
+
+describe('ScanJobContext — reviewJob', () => {
+  it('sets reviewingJob when called with valid job id', async () => {
+    const { result } = await renderScanJobs();
+    mockGet.mockResolvedValueOnce({ data: [{ title: 'Dune', author: 'Herbert' }] });
+
+    await act(async () => {
+      await result.current.startScan('text', undefined, 'Dune');
+    });
+    expect(result.current.jobs[0]?.status).toBe('complete');
+
+    act(() => {
+      result.current.reviewJob(result.current.jobs[0].id);
+    });
+
+    expect(result.current.reviewingJob).toBeTruthy();
+    expect(result.current.reviewingJob?.id).toBe(result.current.jobs[0].id);
+  });
+
+  it('dismissReview clears reviewingJob', async () => {
+    const { result } = await renderScanJobs();
+    mockGet.mockResolvedValueOnce({ data: [{ title: 'Dune', author: 'Herbert' }] });
+
+    await act(async () => {
+      await result.current.startScan('text', undefined, 'Dune');
+    });
+
+    act(() => {
+      result.current.reviewJob(result.current.jobs[0].id);
+    });
+    expect(result.current.reviewingJob).toBeTruthy();
+
+    act(() => {
+      result.current.dismissReview();
+    });
+    expect(result.current.reviewingJob).toBeNull();
+  });
+});
+
+describe('ScanJobContext — handleSelectBook', () => {
+  it('posts to wishlist and removes job on success', async () => {
+    const { result } = await renderScanJobs();
+    mockGet.mockResolvedValueOnce({ data: [{ title: 'Dune', author: 'Herbert' }] });
+    mockPost.mockResolvedValueOnce({});
+
+    await act(async () => {
+      await result.current.startScan('text', undefined, 'Dune');
+    });
+    expect(result.current.jobs[0]?.status).toBe('complete');
+
+    act(() => {
+      result.current.reviewJob(result.current.jobs[0].id);
+    });
+
+    await act(async () => {
+      await result.current.handleSelectBook({
+        title: 'Dune',
+        author: 'Herbert',
+        subjects: [],
+        confidence: 0.9,
+        already_in_library: false,
+        editions: [],
+      });
+    });
+
+    expect(mockPost).toHaveBeenCalledWith('/wishlist', expect.objectContaining({ title: 'Dune' }));
+    expect(result.current.reviewingJob).toBeNull();
+  });
+});

--- a/frontend/__tests__/unit/ScanScreen.test.tsx
+++ b/frontend/__tests__/unit/ScanScreen.test.tsx
@@ -182,7 +182,10 @@ describe('ScanScreen — native capture flow', () => {
     mockTakePictureAsync.mockResolvedValue({ uri: 'file://test.jpg' });
     const { getByLabelText } = render(<ScanScreen />);
     await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
-    expect(mockStartScan).toHaveBeenCalledWith('image', expect.stringContaining('file:///docs/scan-queue/'));
+    expect(mockStartScan).toHaveBeenCalledWith(
+      'image',
+      expect.stringContaining('file:///docs/scan-queue/')
+    );
   });
 
   it('copies photo to document directory before starting scan', async () => {

--- a/frontend/__tests__/unit/ScanScreen.test.tsx
+++ b/frontend/__tests__/unit/ScanScreen.test.tsx
@@ -1,17 +1,25 @@
 import React from 'react';
-import { Alert, Platform } from 'react-native';
-import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import { Platform } from 'react-native';
+import { act, fireEvent, render } from '@testing-library/react-native';
 
 import ScanScreen from '../../app/(tabs)/scan';
 
-const mockPost = jest.fn();
-const mockGet = jest.fn();
+// ── Mocks ───────────────────────────────────────────────────────────────────
 
-jest.mock('../../lib/api', () => ({
-  api: {
-    post: (...args: unknown[]) => mockPost(...args),
-    get: (...args: unknown[]) => mockGet(...args),
-  },
+const mockStartScan = jest.fn();
+
+jest.mock('../../hooks/useScanJobs', () => ({
+  useScanJobs: () => ({
+    jobs: [],
+    reviewingJob: null,
+    startScan: mockStartScan,
+    retryScan: jest.fn(),
+    queueForLater: jest.fn(),
+    reviewJob: jest.fn(),
+    dismissReview: jest.fn(),
+    dismissJob: jest.fn(),
+    handleSelectBook: jest.fn(),
+  }),
 }));
 
 const mockTakePictureAsync = jest.fn();
@@ -32,6 +40,13 @@ jest.mock('expo-camera', () => {
   };
 });
 
+jest.mock('expo-file-system', () => ({
+  documentDirectory: 'file:///docs/',
+  getInfoAsync: jest.fn().mockResolvedValue({ exists: true }),
+  makeDirectoryAsync: jest.fn().mockResolvedValue(undefined),
+  copyAsync: jest.fn().mockResolvedValue(undefined),
+}));
+
 jest.mock('../../hooks/useTheme', () => ({
   useTheme: () => ({
     theme: {
@@ -50,56 +65,8 @@ jest.mock('../../hooks/useTheme', () => ({
   }),
 }));
 
-jest.mock('../../components/LoadingSpinner', () => ({
-  LoadingSpinner: ({ message }: { message?: string }) => {
-    const { Text } = require('react-native');
-    return <Text testID="loading-spinner">{message}</Text>;
-  },
-}));
-
-jest.mock('../../components/BookCandidatePicker', () => ({
-  BookCandidatePicker: ({
-    visible,
-    onSelect,
-    onDismiss,
-    candidates,
-  }: {
-    visible: boolean;
-    onSelect: (book: unknown) => void;
-    onDismiss: () => void;
-    candidates: { title: string }[];
-  }) => {
-    if (!visible) return null;
-    const { Text, Pressable } = require('react-native');
-    return (
-      <>
-        <Pressable testID="dismiss-picker" onPress={onDismiss}>
-          <Text>dismiss</Text>
-        </Pressable>
-        {candidates.map((c, i) => (
-          <Pressable key={i} testID={`select-book-${i}`} onPress={() => onSelect(c)}>
-            <Text>{c.title}</Text>
-          </Pressable>
-        ))}
-      </>
-    );
-  },
-}));
-
-jest.mock('axios', () => ({
-  isAxiosError: (e: unknown) => (e as { isAxiosError?: boolean }).isAxiosError === true,
-}));
-
 const { useCameraPermissions } = require('expo-camera');
 
-function makeAxiosError(status: number) {
-  return Object.assign(new Error('axios'), {
-    isAxiosError: true,
-    response: { status },
-  });
-}
-
-// Helper: set Platform.OS for a describe block
 function setPlatform(os: string) {
   let original: string;
   beforeEach(() => {
@@ -113,7 +80,6 @@ function setPlatform(os: string) {
 
 beforeEach(() => {
   jest.clearAllMocks();
-  jest.spyOn(Alert, 'alert').mockImplementation(() => {});
   useCameraPermissions.mockReturnValue([{ granted: true }, mockRequestPermission]);
 });
 
@@ -137,58 +103,31 @@ describe('ScanScreen — search mode', () => {
     expect(getByLabelText('Search for book')).toBeTruthy();
   });
 
-  it('shows loading spinner while searching', async () => {
-    let resolveGet!: (v: unknown) => void;
-    mockGet.mockReturnValue(
-      new Promise((res) => {
-        resolveGet = res;
-      })
-    );
-    const { getByLabelText, getByTestId } = renderInSearchMode();
+  it('calls startScan with text type when search is pressed', () => {
+    const { getByLabelText } = renderInSearchMode();
     fireEvent.changeText(getByLabelText('Book title or author search'), 'Dune');
     fireEvent.press(getByLabelText('Search for book'));
-    expect(getByTestId('loading-spinner')).toBeTruthy();
-    await act(async () => resolveGet({ data: [] }));
+    expect(mockStartScan).toHaveBeenCalledWith('text', undefined, 'Dune');
   });
 
-  it('shows picker when search returns results', async () => {
-    mockGet.mockResolvedValue({ data: [{ title: 'Dune', author: 'Herbert' }] });
-    const { getByLabelText, getByTestId } = renderInSearchMode();
+  it('clears query after search', () => {
+    const { getByLabelText } = renderInSearchMode();
     fireEvent.changeText(getByLabelText('Book title or author search'), 'Dune');
-    await act(async () => fireEvent.press(getByLabelText('Search for book')));
-    await waitFor(() => expect(getByTestId('dismiss-picker')).toBeTruthy());
+    fireEvent.press(getByLabelText('Search for book'));
+    expect(getByLabelText('Book title or author search').props.value).toBe('');
   });
 
-  it('alerts when search returns empty results', async () => {
-    mockGet.mockResolvedValue({ data: [] });
+  it('does nothing if search query is empty', () => {
     const { getByLabelText } = renderInSearchMode();
-    fireEvent.changeText(getByLabelText('Book title or author search'), 'xyz');
-    await act(async () => fireEvent.press(getByLabelText('Search for book')));
-    expect(Alert.alert).toHaveBeenCalledWith('No results', expect.any(String));
+    fireEvent.press(getByLabelText('Search for book'));
+    expect(mockStartScan).not.toHaveBeenCalled();
   });
 
-  it('alerts on search error', async () => {
-    mockGet.mockRejectedValue(new Error('network'));
-    const { getByLabelText } = renderInSearchMode();
-    fireEvent.changeText(getByLabelText('Book title or author search'), 'xyz');
-    await act(async () => fireEvent.press(getByLabelText('Search for book')));
-    expect(Alert.alert).toHaveBeenCalled();
-  });
-
-  it('does nothing if search query is empty', async () => {
-    const { getByLabelText } = renderInSearchMode();
-    await act(async () => fireEvent.press(getByLabelText('Search for book')));
-    expect(mockGet).not.toHaveBeenCalled();
-  });
-
-  it('dismisses picker on dismiss press', async () => {
-    mockGet.mockResolvedValue({ data: [{ title: 'Dune', author: 'Herbert' }] });
-    const { getByLabelText, getByTestId, queryByTestId } = renderInSearchMode();
+  it('does not show a loading spinner (search runs in background)', () => {
+    const { getByLabelText, queryByTestId } = renderInSearchMode();
     fireEvent.changeText(getByLabelText('Book title or author search'), 'Dune');
-    await act(async () => fireEvent.press(getByLabelText('Search for book')));
-    await waitFor(() => expect(getByTestId('dismiss-picker')).toBeTruthy());
-    fireEvent.press(getByTestId('dismiss-picker'));
-    expect(queryByTestId('dismiss-picker')).toBeNull();
+    fireEvent.press(getByLabelText('Search for book'));
+    expect(queryByTestId('loading-spinner')).toBeNull();
   });
 });
 
@@ -236,62 +175,46 @@ describe('ScanScreen — native camera facing toggle', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Native camera mode — capture flow
+// Native camera mode — capture flow (background)
 // ---------------------------------------------------------------------------
 describe('ScanScreen — native capture flow', () => {
-  it('shows loading spinner during capture (camera stays mounted)', async () => {
-    let resolveTake!: (v: unknown) => void;
-    mockTakePictureAsync.mockReturnValue(
-      new Promise((res) => {
-        resolveTake = res;
-      })
+  it('calls startScan with image type after photo capture', async () => {
+    mockTakePictureAsync.mockResolvedValue({ uri: 'file://test.jpg' });
+    const { getByLabelText } = render(<ScanScreen />);
+    await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
+    expect(mockStartScan).toHaveBeenCalledWith('image', expect.stringContaining('file:///docs/scan-queue/'));
+  });
+
+  it('copies photo to document directory before starting scan', async () => {
+    const FileSystem = require('expo-file-system');
+    mockTakePictureAsync.mockResolvedValue({ uri: 'file://tmp/photo.jpg' });
+    const { getByLabelText } = render(<ScanScreen />);
+    await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
+    expect(FileSystem.copyAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ from: 'file://tmp/photo.jpg' })
     );
-    const { getByLabelText, getByTestId } = render(<ScanScreen />);
-    fireEvent.press(getByLabelText('Capture book cover'));
-    // Loading spinner visible while camera processes
-    expect(getByTestId('loading-spinner')).toBeTruthy();
-    await act(async () => resolveTake({ uri: 'file://test.jpg' }));
   });
 
-  it('shows picker after successful scan', async () => {
+  it('does not show loading spinner (search runs in background)', async () => {
     mockTakePictureAsync.mockResolvedValue({ uri: 'file://test.jpg' });
-    mockPost.mockResolvedValue({ data: [{ title: 'Dune', author: 'Herbert' }] });
-    const { getByLabelText, getByTestId } = render(<ScanScreen />);
+    const { getByLabelText, queryByTestId } = render(<ScanScreen />);
     await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
-    await waitFor(() => expect(getByTestId('dismiss-picker')).toBeTruthy());
-    expect(mockPost).toHaveBeenCalledWith('/scan', expect.any(FormData), expect.any(Object));
+    expect(queryByTestId('loading-spinner')).toBeNull();
   });
 
-  it('alerts when scan returns no books', async () => {
-    mockTakePictureAsync.mockResolvedValue({ uri: 'file://test.jpg' });
-    mockPost.mockResolvedValue({ data: [] });
-    const { getByLabelText } = render(<ScanScreen />);
-    await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
-    expect(Alert.alert).toHaveBeenCalledWith('No books found', expect.any(String));
-  });
-
-  it('alerts with scan-unavailable message on 503', async () => {
-    mockTakePictureAsync.mockResolvedValue({ uri: 'file://test.jpg' });
-    mockPost.mockRejectedValue(makeAxiosError(503));
-    const { getByLabelText } = render(<ScanScreen />);
-    await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
-    expect(Alert.alert).toHaveBeenCalledWith('Scan unavailable', expect.any(String));
-  });
-
-  it('alerts with generic scan-failed message on other errors', async () => {
-    mockTakePictureAsync.mockResolvedValue({ uri: 'file://test.jpg' });
-    mockPost.mockRejectedValue(new Error('network'));
-    const { getByLabelText } = render(<ScanScreen />);
-    await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
-    expect(Alert.alert).toHaveBeenCalledWith('Scan failed', expect.any(String));
-  });
-
-  it('exits early without posting when takePictureAsync returns no uri', async () => {
+  it('exits early without starting scan when takePictureAsync returns no uri', async () => {
     mockTakePictureAsync.mockResolvedValue({ uri: null });
     const { getByLabelText } = render(<ScanScreen />);
     await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
-    expect(mockPost).not.toHaveBeenCalled();
-    expect(Alert.alert).not.toHaveBeenCalled();
+    expect(mockStartScan).not.toHaveBeenCalled();
+  });
+
+  it('camera controls remain visible after capture (no loading overlay)', async () => {
+    mockTakePictureAsync.mockResolvedValue({ uri: 'file://test.jpg' });
+    const { getByLabelText } = render(<ScanScreen />);
+    await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
+    expect(getByLabelText('Capture book cover')).toBeTruthy();
+    expect(getByLabelText('Flip camera')).toBeTruthy();
   });
 });
 
@@ -307,8 +230,6 @@ describe('ScanScreen — web camera mode', () => {
     expect(queryByLabelText('Flip camera')).toBeNull();
   });
 
-  // RNTL's getByTestId doesn't traverse host string elements (e.g. <input>).
-  // Use UNSAFE_getAllByType to find the raw HTML input in the test renderer tree.
   function getWebInput(utils: ReturnType<typeof render>) {
     const [input] = utils.UNSAFE_getAllByType('input' as unknown as React.ComponentType);
     return input;
@@ -322,89 +243,32 @@ describe('ScanScreen — web camera mode', () => {
     expect(input.props.capture).toBe('environment');
   });
 
-  it('shows picker after file is selected and scan succeeds', async () => {
+  it('calls startScan with image type after file selection', async () => {
     const mockFile = new File(['img'], 'scan.jpg', { type: 'image/jpeg' });
-    mockPost.mockResolvedValue({ data: [{ title: 'Dune', author: 'Herbert' }] });
     const utils = render(<ScanScreen />);
     const input = getWebInput(utils);
     await act(async () => fireEvent(input, 'change', { target: { files: [mockFile] } }));
-    await waitFor(() => expect(utils.getByTestId('dismiss-picker')).toBeTruthy());
-    expect(mockPost).toHaveBeenCalledWith('/scan', expect.any(FormData), expect.any(Object));
-  });
-
-  it('shows loading spinner during web file processing', async () => {
-    let resolvePost!: (v: unknown) => void;
-    mockPost.mockReturnValue(
-      new Promise((res) => {
-        resolvePost = res;
-      })
-    );
-    const mockFile = new File(['img'], 'scan.jpg', { type: 'image/jpeg' });
-    const utils = render(<ScanScreen />);
-    const input = getWebInput(utils);
-    act(() => {
-      fireEvent(input, 'change', { target: { files: [mockFile] } });
-    });
-    expect(utils.getByTestId('loading-spinner')).toBeTruthy();
-    await act(async () => resolvePost({ data: [] }));
-  });
-
-  it('alerts when web scan returns no books', async () => {
-    const mockFile = new File(['img'], 'scan.jpg', { type: 'image/jpeg' });
-    mockPost.mockResolvedValue({ data: [] });
-    const utils = render(<ScanScreen />);
-    const input = getWebInput(utils);
-    await act(async () => fireEvent(input, 'change', { target: { files: [mockFile] } }));
-    expect(Alert.alert).toHaveBeenCalledWith('No books found', expect.any(String));
-  });
-
-  it('alerts with scan-unavailable on 503 from web', async () => {
-    const mockFile = new File(['img'], 'scan.jpg', { type: 'image/jpeg' });
-    mockPost.mockRejectedValue(makeAxiosError(503));
-    const utils = render(<ScanScreen />);
-    const input = getWebInput(utils);
-    await act(async () => fireEvent(input, 'change', { target: { files: [mockFile] } }));
-    expect(Alert.alert).toHaveBeenCalledWith('Scan unavailable', expect.any(String));
-  });
-
-  it('alerts with scan-failed on generic error from web', async () => {
-    const mockFile = new File(['img'], 'scan.jpg', { type: 'image/jpeg' });
-    mockPost.mockRejectedValue(new Error('network'));
-    const utils = render(<ScanScreen />);
-    const input = getWebInput(utils);
-    await act(async () => fireEvent(input, 'change', { target: { files: [mockFile] } }));
-    expect(Alert.alert).toHaveBeenCalledWith('Scan failed', expect.any(String));
+    expect(mockStartScan).toHaveBeenCalledWith('image', expect.any(String));
   });
 
   it('does nothing when change fires with no file selected', async () => {
     const utils = render(<ScanScreen />);
     const input = getWebInput(utils);
     await act(async () => fireEvent(input, 'change', { target: { files: [] } }));
-    expect(mockPost).not.toHaveBeenCalled();
-    expect(Alert.alert).not.toHaveBeenCalled();
+    expect(mockStartScan).not.toHaveBeenCalled();
   });
 });
 
 // ---------------------------------------------------------------------------
-// Mode switch — camera controls disappear when switching to search
+// Mode switch
 // ---------------------------------------------------------------------------
 describe('ScanScreen — mode switch hides camera controls (native)', () => {
   it('hides capture and flip buttons after switching to search mode', () => {
     const { getByLabelText, queryByLabelText } = render(<ScanScreen />);
-    // Camera controls visible initially
     expect(getByLabelText('Capture book cover')).toBeTruthy();
-    expect(getByLabelText('Flip camera')).toBeTruthy();
-    // Switch to search
     fireEvent.press(getByLabelText('Text search mode'));
-    // Camera controls gone
     expect(queryByLabelText('Capture book cover')).toBeNull();
     expect(queryByLabelText('Flip camera')).toBeNull();
-  });
-
-  it('shows search input after switching to search mode', () => {
-    const { getByLabelText } = render(<ScanScreen />);
-    fireEvent.press(getByLabelText('Text search mode'));
-    expect(getByLabelText('Book title or author search')).toBeTruthy();
   });
 
   it('shows capture and flip buttons after switching back to camera mode', () => {
@@ -419,154 +283,17 @@ describe('ScanScreen — mode switch hides camera controls (native)', () => {
 describe('ScanScreen — mode switch hides camera controls (web)', () => {
   setPlatform('web');
 
-  function getWebInput(utils: ReturnType<typeof render>) {
-    const [input] = utils.UNSAFE_getAllByType('input' as unknown as React.ComponentType);
-    return input;
-  }
-
-  it('hides capture button and file input after switching to search mode', () => {
+  it('hides capture button after switching to search mode', () => {
     const utils = render(<ScanScreen />);
-    // Camera mode: capture button present
     expect(utils.getByLabelText('Capture book cover')).toBeTruthy();
-    // Switch to search
     fireEvent.press(utils.getByLabelText('Text search mode'));
-    // Capture button gone; file input no longer rendered
     expect(utils.queryByLabelText('Capture book cover')).toBeNull();
-    // UNSAFE_getAllByType throws on empty — use try/catch to assert absence
-    expect(() => utils.UNSAFE_getAllByType('input' as unknown as React.ComponentType)).toThrow();
   });
 
-  it('shows capture button and file input after switching back to camera mode', () => {
+  it('shows capture button after switching back to camera mode', () => {
     const utils = render(<ScanScreen />);
     fireEvent.press(utils.getByLabelText('Text search mode'));
     fireEvent.press(utils.getByLabelText('Camera scan mode'));
     expect(utils.getByLabelText('Capture book cover')).toBeTruthy();
-    const input = getWebInput(utils);
-    expect(input.props.type).toBe('file');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Full end-to-end flows
-// ---------------------------------------------------------------------------
-describe('ScanScreen — full native capture → wishlist flow', () => {
-  it('captures, shows picker, selects book, posts to wishlist, alerts success', async () => {
-    const book = { title: 'Dune', author: 'Herbert' };
-    mockTakePictureAsync.mockResolvedValue({ uri: 'file://test.jpg' });
-    mockPost
-      .mockResolvedValueOnce({ data: [book] }) // /scan
-      .mockResolvedValueOnce({}); // /wishlist
-    const { getByLabelText, getByTestId } = render(<ScanScreen />);
-
-    // Step 1: press capture
-    await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
-
-    // Step 2: picker appears
-    await waitFor(() => expect(getByTestId('select-book-0')).toBeTruthy());
-    expect(mockPost).toHaveBeenCalledWith('/scan', expect.any(FormData), expect.any(Object));
-
-    // Step 3: select the book
-    await act(async () => fireEvent.press(getByTestId('select-book-0')));
-
-    // Step 4: wishlist POST and success alert
-    expect(mockPost).toHaveBeenCalledWith('/wishlist', expect.objectContaining({ title: 'Dune' }));
-    expect(Alert.alert).toHaveBeenCalledWith('Added to wishlist', expect.any(String));
-  });
-
-  it('returns to idle if wishlist save fails', async () => {
-    const book = { title: 'Dune', author: 'Herbert' };
-    mockTakePictureAsync.mockResolvedValue({ uri: 'file://test.jpg' });
-    mockPost
-      .mockResolvedValueOnce({ data: [book] })
-      .mockRejectedValueOnce(new Error('save failed'));
-    const { getByLabelText, getByTestId, queryByTestId } = render(<ScanScreen />);
-
-    await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
-    await waitFor(() => expect(getByTestId('select-book-0')).toBeTruthy());
-    await act(async () => fireEvent.press(getByTestId('select-book-0')));
-
-    expect(Alert.alert).toHaveBeenCalledWith('Could not save', expect.any(String));
-    // Picker is dismissed after failed save
-    expect(queryByTestId('select-book-0')).toBeNull();
-  });
-});
-
-describe('ScanScreen — full web capture → wishlist flow', () => {
-  setPlatform('web');
-
-  function getWebInput(utils: ReturnType<typeof render>) {
-    const [input] = utils.UNSAFE_getAllByType('input' as unknown as React.ComponentType);
-    return input;
-  }
-
-  it('selects file, shows picker, selects book, posts to wishlist, alerts success', async () => {
-    const book = { title: 'Dune', author: 'Herbert' };
-    const mockFile = new File(['img'], 'scan.jpg', { type: 'image/jpeg' });
-    mockPost
-      .mockResolvedValueOnce({ data: [book] }) // /scan
-      .mockResolvedValueOnce({}); // /wishlist
-    const utils = render(<ScanScreen />);
-
-    // Step 1: fire file change
-    const input = getWebInput(utils);
-    await act(async () => fireEvent(input, 'change', { target: { files: [mockFile] } }));
-
-    // Step 2: picker appears
-    await waitFor(() => expect(utils.getByTestId('select-book-0')).toBeTruthy());
-    expect(mockPost).toHaveBeenCalledWith('/scan', expect.any(FormData), expect.any(Object));
-
-    // Step 3: select the book
-    await act(async () => fireEvent.press(utils.getByTestId('select-book-0')));
-
-    // Step 4: wishlist POST and success alert
-    expect(mockPost).toHaveBeenCalledWith('/wishlist', expect.objectContaining({ title: 'Dune' }));
-    expect(Alert.alert).toHaveBeenCalledWith('Added to wishlist', expect.any(String));
-  });
-
-  it('returns to idle if wishlist save fails after web scan', async () => {
-    const book = { title: 'Dune', author: 'Herbert' };
-    const mockFile = new File(['img'], 'scan.jpg', { type: 'image/jpeg' });
-    mockPost
-      .mockResolvedValueOnce({ data: [book] })
-      .mockRejectedValueOnce(new Error('save failed'));
-    const utils = render(<ScanScreen />);
-
-    const input = getWebInput(utils);
-    await act(async () => fireEvent(input, 'change', { target: { files: [mockFile] } }));
-    await waitFor(() => expect(utils.getByTestId('select-book-0')).toBeTruthy());
-    await act(async () => fireEvent.press(utils.getByTestId('select-book-0')));
-
-    expect(Alert.alert).toHaveBeenCalledWith('Could not save', expect.any(String));
-    expect(utils.queryByTestId('select-book-0')).toBeNull();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Select book
-// ---------------------------------------------------------------------------
-describe('ScanScreen — select book', () => {
-  it('posts to wishlist and alerts on success', async () => {
-    mockGet.mockResolvedValue({ data: [{ title: 'Dune', author: 'Herbert' }] });
-    mockPost.mockResolvedValue({});
-    const { getByLabelText, getByTestId } = render(<ScanScreen />);
-    fireEvent.press(getByLabelText('Text search mode'));
-    fireEvent.changeText(getByLabelText('Book title or author search'), 'Dune');
-    await act(async () => fireEvent.press(getByLabelText('Search for book')));
-    await waitFor(() => expect(getByTestId('select-book-0')).toBeTruthy());
-    await act(async () => fireEvent.press(getByTestId('select-book-0')));
-    expect(mockPost).toHaveBeenCalledWith('/wishlist', expect.objectContaining({ title: 'Dune' }));
-    expect(Alert.alert).toHaveBeenCalled();
-  });
-
-  it('alerts on save error', async () => {
-    mockGet.mockResolvedValue({ data: [{ title: 'Dune', author: 'Herbert' }] });
-    mockPost.mockRejectedValue(new Error('save failed'));
-    const { getByLabelText, getByTestId } = render(<ScanScreen />);
-    fireEvent.press(getByLabelText('Text search mode'));
-    fireEvent.changeText(getByLabelText('Book title or author search'), 'Dune');
-    await act(async () => fireEvent.press(getByLabelText('Search for book')));
-    await waitFor(() => expect(getByTestId('select-book-0')).toBeTruthy());
-    await act(async () => fireEvent.press(getByTestId('select-book-0')));
-    expect(Alert.alert).toHaveBeenCalled();
   });
 });

--- a/frontend/__tests__/unit/scanJobStorage.test.ts
+++ b/frontend/__tests__/unit/scanJobStorage.test.ts
@@ -42,7 +42,16 @@ describe('scanJobStorage', () => {
     const jobWithResults: ScanJob = {
       ...sampleJob,
       status: 'complete',
-      results: [{ title: 'Dune', author: 'Herbert', subjects: [], confidence: 0.9, already_in_library: false, editions: [] }],
+      results: [
+        {
+          title: 'Dune',
+          author: 'Herbert',
+          subjects: [],
+          confidence: 0.9,
+          already_in_library: false,
+          editions: [],
+        },
+      ],
     };
     await saveJobs([jobWithResults]);
     const loaded = await loadJobs();
@@ -57,10 +66,7 @@ describe('scanJobStorage', () => {
   });
 
   it('handles multiple jobs', async () => {
-    const jobs = [
-      sampleJob,
-      { ...sampleJob, id: 'test-2', query: 'Foundation' },
-    ];
+    const jobs = [sampleJob, { ...sampleJob, id: 'test-2', query: 'Foundation' }];
     await saveJobs(jobs);
     const loaded = await loadJobs();
     expect(loaded).toHaveLength(2);

--- a/frontend/__tests__/unit/scanJobStorage.test.ts
+++ b/frontend/__tests__/unit/scanJobStorage.test.ts
@@ -1,0 +1,68 @@
+import { Platform } from 'react-native';
+import { saveJobs, loadJobs, clearJobs } from '../../lib/scanJobStorage';
+import type { ScanJob } from '../../lib/scanJob';
+
+// Force web platform so we use the in-memory store (no AsyncStorage needed).
+beforeAll(() => {
+  Object.defineProperty(Platform, 'OS', { value: 'web', configurable: true });
+});
+
+afterAll(() => {
+  Object.defineProperty(Platform, 'OS', { value: 'ios', configurable: true });
+});
+
+const sampleJob: ScanJob = {
+  id: 'test-1',
+  type: 'text',
+  status: 'queued',
+  createdAt: 1234567890,
+  query: 'Dune',
+  retryCount: 0,
+};
+
+describe('scanJobStorage', () => {
+  beforeEach(async () => {
+    await clearJobs();
+  });
+
+  it('round-trips save and load', async () => {
+    await saveJobs([sampleJob]);
+    const loaded = await loadJobs();
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].id).toBe('test-1');
+    expect(loaded[0].query).toBe('Dune');
+  });
+
+  it('returns empty array when nothing stored', async () => {
+    const loaded = await loadJobs();
+    expect(loaded).toEqual([]);
+  });
+
+  it('strips results from persisted jobs to save space', async () => {
+    const jobWithResults: ScanJob = {
+      ...sampleJob,
+      status: 'complete',
+      results: [{ title: 'Dune', author: 'Herbert', subjects: [], confidence: 0.9, already_in_library: false, editions: [] }],
+    };
+    await saveJobs([jobWithResults]);
+    const loaded = await loadJobs();
+    expect(loaded[0].results).toBeUndefined();
+  });
+
+  it('clearJobs removes all stored data', async () => {
+    await saveJobs([sampleJob]);
+    await clearJobs();
+    const loaded = await loadJobs();
+    expect(loaded).toEqual([]);
+  });
+
+  it('handles multiple jobs', async () => {
+    const jobs = [
+      sampleJob,
+      { ...sampleJob, id: 'test-2', query: 'Foundation' },
+    ];
+    await saveJobs(jobs);
+    const loaded = await loadJobs();
+    expect(loaded).toHaveLength(2);
+  });
+});

--- a/frontend/app/(tabs)/scan.tsx
+++ b/frontend/app/(tabs)/scan.tsx
@@ -1,147 +1,76 @@
 import React, { useRef, useState } from 'react';
-import { Alert, Platform, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+import { Platform, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
 import { CameraView, useCameraPermissions } from 'expo-camera';
-import { isAxiosError } from 'axios';
+import * as FileSystem from 'expo-file-system';
 import { useTranslation } from 'react-i18next';
 
-import { BookCandidatePicker, EnrichedBook } from '../../components/BookCandidatePicker';
-import { LoadingSpinner } from '../../components/LoadingSpinner';
 import { useTheme } from '../../hooks/useTheme';
-import { api } from '../../lib/api';
+import { useScanJobs } from '../../hooks/useScanJobs';
 
 type InputMode = 'camera' | 'search';
-type ScreenState = 'idle' | 'loading' | 'picker';
 type CameraFacing = 'back' | 'front';
 
 export default function ScanScreen() {
   const { theme } = useTheme();
   const { t } = useTranslation('scan');
+  const { startScan } = useScanJobs();
   const [permission, requestPermission] = useCameraPermissions();
   const [inputMode, setInputMode] = useState<InputMode>('camera');
-  const [screenState, setScreenState] = useState<ScreenState>('idle');
-  const [candidates, setCandidates] = useState<EnrichedBook[]>([]);
   const [query, setQuery] = useState('');
   const [facing, setFacing] = useState<CameraFacing>('back');
+  const [capturing, setCapturing] = useState(false);
   const cameraRef = useRef<CameraView>(null);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const webInputRef = useRef<any>(null);
 
-  function handleScanError(err: unknown) {
-    if (isAxiosError(err) && err.response?.status === 503) {
-      Alert.alert(t('scanUnavailableTitle'), t('scanUnavailableMessage'));
-    } else {
-      Alert.alert(t('scanFailedTitle'), t('scanFailedMessage'));
-    }
-  }
-
-  async function submitScan(formData: FormData) {
-    const response = await api.post<EnrichedBook[]>('/scan', formData, {
-      // transformRequest runs after all header merging, so we can adjust
-      // Content-Type reliably here:
-      //   Web   — delete it; the browser XHR sets multipart/form-data with the
-      //           correct boundary automatically when the body is a FormData.
-      //   Native — set it explicitly; React Native's network layer adds the
-      //            boundary when the hint is 'multipart/form-data'.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      transformRequest: [
-        (data: FormData, headers: any) => {
-          if (Platform.OS === 'web') {
-            headers.delete('Content-Type');
-          } else {
-            headers.set('Content-Type', 'multipart/form-data');
-          }
-          return data;
-        },
-      ],
-    });
-    if (!response.data || response.data.length === 0) {
-      setScreenState('idle');
-      Alert.alert(t('noBooksFoundTitle'), t('noBooksFoundMessage'));
-      return;
-    }
-    setCandidates(response.data);
-    setScreenState('picker');
-  }
-
-  // Web: file input onChange — receives a File object directly from the browser
+  // Web: file input onChange — receives a File object directly from the browser.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async function handleWebFileChange(e: any) {
     const file: File | undefined = e?.target?.files?.[0];
     if (!file) return;
-    // Reset so the same file can be re-selected
     if (webInputRef.current) webInputRef.current.value = '';
-    setScreenState('loading');
+
+    // On web, pass the File object URL. The ScanJobContext handles FormData.
+    let uri: string;
     try {
-      const formData = new FormData();
-      formData.append('file', file, 'scan.jpg');
-      await submitScan(formData);
-    } catch (err) {
-      setScreenState('idle');
-      handleScanError(err);
+      uri = URL.createObjectURL(file);
+    } catch {
+      uri = file.name;
     }
+    startScan('image', uri);
   }
 
-  // Native: camera shutter
+  // Native: camera shutter — take photo, persist to document dir, start background scan.
   async function handleCapture() {
-    if (!cameraRef.current) return;
-    setScreenState('loading');
+    if (!cameraRef.current || capturing) return;
+    setCapturing(true);
     try {
       const photo = await cameraRef.current.takePictureAsync({
         quality: 0.7,
         base64: false,
       });
-      if (!photo?.uri) {
-        setScreenState('idle');
-        return;
+      if (!photo?.uri) return;
+
+      // Copy temp file to persistent document directory.
+      const destDir = `${FileSystem.documentDirectory}scan-queue/`;
+      const info = await FileSystem.getInfoAsync(destDir);
+      if (!info.exists) {
+        await FileSystem.makeDirectoryAsync(destDir, { intermediates: true });
       }
-      const formData = new FormData();
-      formData.append('file', {
-        uri: photo.uri,
-        name: 'scan.jpg',
-        type: 'image/jpeg',
-      } as unknown as Blob);
-      await submitScan(formData);
-    } catch (err) {
-      setScreenState('idle');
-      handleScanError(err);
+      const destUri = `${destDir}${Date.now()}.jpg`;
+      await FileSystem.copyAsync({ from: photo.uri, to: destUri });
+
+      startScan('image', destUri);
+    } finally {
+      setCapturing(false);
     }
   }
 
-  async function handleSearch() {
+  function handleSearch() {
     const q = query.trim();
     if (!q) return;
-    setScreenState('loading');
-    try {
-      const response = await api.get<EnrichedBook[]>('/books/search', { params: { q } });
-      if (!response.data || response.data.length === 0) {
-        setScreenState('idle');
-        Alert.alert(t('noResultsTitle'), t('noResultsMessage'));
-        return;
-      }
-      setCandidates(response.data);
-      setScreenState('picker');
-    } catch {
-      setScreenState('idle');
-      Alert.alert(t('searchFailedTitle'), t('searchFailedMessage'));
-    }
-  }
-
-  async function handleSelect(book: EnrichedBook) {
-    setCandidates([]);
-    setScreenState('loading');
-    try {
-      await api.post('/wishlist', book);
-      setScreenState('idle');
-      Alert.alert(t('addedTitle'), t('addedMessage', { title: book.title }));
-    } catch {
-      setScreenState('idle');
-      Alert.alert(t('couldNotSaveTitle'), t('couldNotSaveMessage'));
-    }
-  }
-
-  function handleDismiss() {
-    setCandidates([]);
-    setScreenState('idle');
+    startScan('text', undefined, q);
+    setQuery('');
   }
 
   const modeToggle = (
@@ -194,16 +123,6 @@ export default function ScanScreen() {
 
   // ── Search mode ──────────────────────────────────────────────────────────
   if (inputMode === 'search') {
-    if (screenState === 'loading') {
-      // Keep modeToggle visible so the user can switch back while a search
-      // (or a camera scan that was mid-flight when they switched) is running.
-      return (
-        <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
-          {modeToggle}
-          <LoadingSpinner message={t('loading')} />
-        </View>
-      );
-    }
     return (
       <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
         {modeToggle}
@@ -235,26 +154,15 @@ export default function ScanScreen() {
             <Text style={styles.searchButtonText}>{t('searchButton')}</Text>
           </Pressable>
         </View>
-        <BookCandidatePicker
-          visible={screenState === 'picker'}
-          candidates={candidates}
-          onSelect={handleSelect}
-          onDismiss={handleDismiss}
-        />
       </View>
     );
   }
 
   // ── Web camera mode ───────────────────────────────────────────────────────
-  // expo-camera's CameraView does not work reliably on iOS web browsers.
-  // Use a native <input type="file" capture="environment"> instead — this
-  // opens the device's built-in camera app (rear lens by default) and
-  // returns a proper File object that FormData understands.
   if (Platform.OS === 'web') {
     return (
       <>
         {React.createElement('input', {
-          // testID lets @testing-library/react-native find this node in tests
           testID: 'web-file-input',
           ref: webInputRef,
           type: 'file',
@@ -265,25 +173,15 @@ export default function ScanScreen() {
         })}
         <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
           {modeToggle}
-          {screenState === 'loading' ? (
-            <LoadingSpinner message={t('loading')} />
-          ) : (
-            <Pressable
-              style={[styles.webCaptureButton, { backgroundColor: theme.colors.primary }]}
-              onPress={() => webInputRef.current?.click()}
-              accessibilityRole="button"
-              accessibilityLabel={t('captureA11y')}
-              accessibilityHint={t('captureHint')}
-            >
-              <Text style={styles.webCaptureButtonText}>{t('takePhoto')}</Text>
-            </Pressable>
-          )}
-          <BookCandidatePicker
-            visible={screenState === 'picker'}
-            candidates={candidates}
-            onSelect={handleSelect}
-            onDismiss={handleDismiss}
-          />
+          <Pressable
+            style={[styles.webCaptureButton, { backgroundColor: theme.colors.primary }]}
+            onPress={() => webInputRef.current?.click()}
+            accessibilityRole="button"
+            accessibilityLabel={t('captureA11y')}
+            accessibilityHint={t('captureHint')}
+          >
+            <Text style={styles.webCaptureButtonText}>{t('takePhoto')}</Text>
+          </Pressable>
         </View>
       </>
     );
@@ -325,50 +223,36 @@ export default function ScanScreen() {
   }
 
   // ── Native camera view ────────────────────────────────────────────────────
-  // Keep CameraView always mounted during loading to prevent iOS from
-  // re-triggering the camera permission dialog when the view re-mounts.
   return (
     <View style={styles.container}>
       <CameraView ref={cameraRef} style={styles.camera} facing={facing}>
         <View style={styles.overlay}>
           {modeToggle}
-          {screenState === 'loading' ? (
-            <LoadingSpinner message={t('loading')} />
-          ) : (
-            <>
-              <View style={[styles.frame, { borderColor: theme.colors.primary }]} />
-              <View style={styles.cameraControls}>
-                <Pressable
-                  style={styles.flipButton}
-                  onPress={() => setFacing((f) => (f === 'back' ? 'front' : 'back'))}
-                  accessibilityRole="button"
-                  accessibilityLabel={t('flipCameraA11y')}
-                >
-                  <Text style={styles.flipButtonText}>{t('flipCamera')}</Text>
-                </Pressable>
-                <Pressable
-                  style={[styles.captureButton, { backgroundColor: theme.colors.primary }]}
-                  onPress={handleCapture}
-                  accessibilityRole="button"
-                  accessibilityLabel={t('captureA11y')}
-                  accessibilityHint={t('captureHint')}
-                >
-                  <View
-                    style={[styles.captureInner, { backgroundColor: theme.colors.background }]}
-                  />
-                </Pressable>
-              </View>
-            </>
-          )}
+          <View style={[styles.frame, { borderColor: theme.colors.primary }]} />
+          <View style={styles.cameraControls}>
+            <Pressable
+              style={styles.flipButton}
+              onPress={() => setFacing((f) => (f === 'back' ? 'front' : 'back'))}
+              accessibilityRole="button"
+              accessibilityLabel={t('flipCameraA11y')}
+            >
+              <Text style={styles.flipButtonText}>{t('flipCamera')}</Text>
+            </Pressable>
+            <Pressable
+              style={[styles.captureButton, { backgroundColor: theme.colors.primary }]}
+              onPress={handleCapture}
+              disabled={capturing}
+              accessibilityRole="button"
+              accessibilityLabel={t('captureA11y')}
+              accessibilityHint={t('captureHint')}
+            >
+              <View
+                style={[styles.captureInner, { backgroundColor: theme.colors.background }]}
+              />
+            </Pressable>
+          </View>
         </View>
       </CameraView>
-
-      <BookCandidatePicker
-        visible={screenState === 'picker'}
-        candidates={candidates}
-        onSelect={handleSelect}
-        onDismiss={handleDismiss}
-      />
     </View>
   );
 }

--- a/frontend/app/(tabs)/scan.tsx
+++ b/frontend/app/(tabs)/scan.tsx
@@ -246,9 +246,7 @@ export default function ScanScreen() {
               accessibilityLabel={t('captureA11y')}
               accessibilityHint={t('captureHint')}
             >
-              <View
-                style={[styles.captureInner, { backgroundColor: theme.colors.background }]}
-              />
+              <View style={[styles.captureInner, { backgroundColor: theme.colors.background }]} />
             </Pressable>
           </View>
         </View>

--- a/frontend/app/(tabs)/scan.tsx
+++ b/frontend/app/(tabs)/scan.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useState } from 'react';
 import { Platform, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
 import { CameraView, useCameraPermissions } from 'expo-camera';
-import * as FileSystem from 'expo-file-system';
+import { copyAsync, documentDirectory, getInfoAsync, makeDirectoryAsync } from 'expo-file-system';
 import { useTranslation } from 'react-i18next';
 
 import { useTheme } from '../../hooks/useTheme';
@@ -52,13 +52,13 @@ export default function ScanScreen() {
       if (!photo?.uri) return;
 
       // Copy temp file to persistent document directory.
-      const destDir = `${FileSystem.documentDirectory}scan-queue/`;
-      const info = await FileSystem.getInfoAsync(destDir);
+      const destDir = `${documentDirectory}scan-queue/`;
+      const info = await getInfoAsync(destDir);
       if (!info.exists) {
-        await FileSystem.makeDirectoryAsync(destDir, { intermediates: true });
+        await makeDirectoryAsync(destDir, { intermediates: true });
       }
       const destUri = `${destDir}${Date.now()}.jpg`;
-      await FileSystem.copyAsync({ from: photo.uri, to: destUri });
+      await copyAsync({ from: photo.uri, to: destUri });
 
       startScan('image', destUri);
     } finally {

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -14,22 +14,46 @@ import '../src/i18n/i18n';
 
 import { Stack } from 'expo-router';
 
+import { BookCandidatePicker } from '../components/BookCandidatePicker';
 import { ErrorBoundary } from '../components/ErrorBoundary';
+import { InAppBanner } from '../components/InAppBanner';
 import { ThemeToggleButton } from '../components/ThemeToggleButton';
 import { AuthProvider } from '../contexts/AuthContext';
+import { BannerProvider } from '../contexts/BannerContext';
+import { ScanJobProvider } from '../contexts/ScanJobContext';
+import { useScanJobs } from '../hooks/useScanJobs';
 import { ThemeProvider } from '../theme';
+
+function GlobalBookPicker() {
+  const { reviewingJob, dismissReview, handleSelectBook } = useScanJobs();
+
+  return (
+    <BookCandidatePicker
+      visible={reviewingJob !== null}
+      candidates={reviewingJob?.results ?? []}
+      onSelect={handleSelectBook}
+      onDismiss={dismissReview}
+    />
+  );
+}
 
 function RootLayout() {
   return (
     <ErrorBoundary>
       <ThemeProvider>
-        <AuthProvider>
-          <Stack
-            screenOptions={{
-              headerRight: () => <ThemeToggleButton />,
-            }}
-          />
-        </AuthProvider>
+        <BannerProvider>
+          <AuthProvider>
+            <ScanJobProvider>
+              <InAppBanner />
+              <Stack
+                screenOptions={{
+                  headerRight: () => <ThemeToggleButton />,
+                }}
+              />
+              <GlobalBookPicker />
+            </ScanJobProvider>
+          </AuthProvider>
+        </BannerProvider>
       </ThemeProvider>
     </ErrorBoundary>
   );

--- a/frontend/components/InAppBanner.tsx
+++ b/frontend/components/InAppBanner.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useRef } from 'react';
+import { Animated, Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { useBanner } from '../hooks/useBanner';
+import { useTheme } from '../hooks/useTheme';
+
+const SLIDE_DURATION = 300;
+const DEFAULT_DISPLAY_DURATION = 5000;
+
+export function InAppBanner() {
+  const { banner, hideBanner } = useBanner();
+  const { theme } = useTheme();
+  const translateY = useRef(new Animated.Value(-120)).current;
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (banner) {
+      Animated.timing(translateY, {
+        toValue: 0,
+        duration: SLIDE_DURATION,
+        useNativeDriver: true,
+      }).start();
+
+      timerRef.current = setTimeout(() => {
+        dismiss();
+      }, banner.duration ?? DEFAULT_DISPLAY_DURATION);
+    } else {
+      translateY.setValue(-120);
+    }
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [banner]);
+
+  function dismiss() {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    Animated.timing(translateY, {
+      toValue: -120,
+      duration: SLIDE_DURATION,
+      useNativeDriver: true,
+    }).start(() => hideBanner());
+  }
+
+  if (!banner) return null;
+
+  const bgColor =
+    banner.type === 'success'
+      ? theme.colors.success
+      : banner.type === 'error'
+        ? theme.colors.error
+        : theme.colors.primary;
+
+  return (
+    <Animated.View
+      style={[styles.container, { backgroundColor: bgColor, transform: [{ translateY }] }]}
+      accessibilityRole="alert"
+      accessibilityLiveRegion="assertive"
+    >
+      <Pressable onPress={dismiss} style={styles.content}>
+        <Text style={styles.message} numberOfLines={2}>
+          {banner.message}
+        </Text>
+        {banner.actions && banner.actions.length > 0 && (
+          <View style={styles.actions}>
+            {banner.actions.map((action) => (
+              <Pressable
+                key={action.label}
+                onPress={() => {
+                  action.onPress();
+                  dismiss();
+                }}
+                style={styles.actionButton}
+                accessibilityRole="button"
+                accessibilityLabel={action.label}
+              >
+                <Text style={styles.actionText}>{action.label}</Text>
+              </Pressable>
+            ))}
+          </View>
+        )}
+      </Pressable>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    zIndex: 9999,
+    paddingTop: 50,
+    paddingBottom: 12,
+    paddingHorizontal: 16,
+  },
+  content: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  message: {
+    flex: 1,
+    color: '#FFFFFF',
+    fontWeight: '600',
+    fontSize: 14,
+  },
+  actions: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  actionButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 4,
+    backgroundColor: 'rgba(255,255,255,0.25)',
+    minWidth: 44,
+    minHeight: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  actionText: {
+    color: '#FFFFFF',
+    fontWeight: '700',
+    fontSize: 13,
+  },
+});

--- a/frontend/contexts/BannerContext.tsx
+++ b/frontend/contexts/BannerContext.tsx
@@ -1,0 +1,44 @@
+import React, { createContext, useCallback, useMemo, useState } from 'react';
+
+export interface BannerAction {
+  label: string;
+  onPress: () => void;
+}
+
+export interface BannerConfig {
+  message: string;
+  type: 'success' | 'error' | 'info';
+  actions?: BannerAction[];
+  duration?: number;
+}
+
+export interface BannerContextValue {
+  banner: BannerConfig | null;
+  showBanner: (config: BannerConfig) => void;
+  hideBanner: () => void;
+}
+
+export const BannerContext = createContext<BannerContextValue>({
+  banner: null,
+  showBanner: () => {},
+  hideBanner: () => {},
+});
+
+export function BannerProvider({ children }: { children: React.ReactNode }) {
+  const [banner, setBanner] = useState<BannerConfig | null>(null);
+
+  const showBanner = useCallback((config: BannerConfig) => {
+    setBanner(config);
+  }, []);
+
+  const hideBanner = useCallback(() => {
+    setBanner(null);
+  }, []);
+
+  const value = useMemo(
+    () => ({ banner, showBanner, hideBanner }),
+    [banner, showBanner, hideBanner],
+  );
+
+  return <BannerContext.Provider value={value}>{children}</BannerContext.Provider>;
+}

--- a/frontend/contexts/BannerContext.tsx
+++ b/frontend/contexts/BannerContext.tsx
@@ -37,7 +37,7 @@ export function BannerProvider({ children }: { children: React.ReactNode }) {
 
   const value = useMemo(
     () => ({ banner, showBanner, hideBanner }),
-    [banner, showBanner, hideBanner],
+    [banner, showBanner, hideBanner]
   );
 
   return <BannerContext.Provider value={value}>{children}</BannerContext.Provider>;

--- a/frontend/contexts/ScanJobContext.tsx
+++ b/frontend/contexts/ScanJobContext.tsx
@@ -1,0 +1,332 @@
+import React, { createContext, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Platform } from 'react-native';
+import NetInfo from '@react-native-community/netinfo';
+import { v4 as uuidv4 } from 'uuid';
+import { useTranslation } from 'react-i18next';
+
+import type { EnrichedBook } from '../components/BookCandidatePicker';
+import { useBanner } from '../hooks/useBanner';
+import { api } from '../lib/api';
+import type { ScanJob, ScanJobType } from '../lib/scanJob';
+import { loadJobs, saveJobs } from '../lib/scanJobStorage';
+
+const MAX_RETRIES = 3;
+const QUEUE_DRAIN_DELAY = 2000;
+
+export interface ScanJobContextValue {
+  jobs: ScanJob[];
+  reviewingJob: ScanJob | null;
+  startScan: (type: ScanJobType, imageUri?: string, query?: string) => void;
+  retryScan: (jobId: string) => void;
+  queueForLater: (jobId: string) => void;
+  reviewJob: (jobId: string) => void;
+  dismissReview: () => void;
+  dismissJob: (jobId: string) => void;
+  handleSelectBook: (book: EnrichedBook) => Promise<void>;
+}
+
+export const ScanJobContext = createContext<ScanJobContextValue>({
+  jobs: [],
+  reviewingJob: null,
+  startScan: () => {},
+  retryScan: () => {},
+  queueForLater: () => {},
+  reviewJob: () => {},
+  dismissReview: () => {},
+  dismissJob: () => {},
+  handleSelectBook: async () => {},
+});
+
+export function ScanJobProvider({ children }: { children: React.ReactNode }) {
+  const [jobs, setJobs] = useState<ScanJob[]>([]);
+  const [reviewingJobId, setReviewingJobId] = useState<string | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const drainingRef = useRef(false);
+  const executeScanRef = useRef<(job: ScanJob) => Promise<void>>(async () => {});
+  const { showBanner } = useBanner();
+  const { t } = useTranslation('scan');
+
+  // Persist jobs whenever they change (after initial load).
+  useEffect(() => {
+    if (loaded) {
+      saveJobs(jobs);
+    }
+  }, [jobs, loaded]);
+
+  // Load persisted jobs on mount. Reset interrupted searches to pending.
+  useEffect(() => {
+    (async () => {
+      const persisted = await loadJobs();
+      const restored = persisted.map((j) =>
+        j.status === 'searching' ? { ...j, status: 'pending' as const } : j,
+      );
+      setJobs(restored);
+      setLoaded(true);
+    })();
+  }, []);
+
+  // Listen for connectivity changes and drain queued jobs.
+  useEffect(() => {
+    const unsubscribe = NetInfo.addEventListener((state) => {
+      if (state.isConnected && !drainingRef.current) {
+        drainQueue();
+      }
+    });
+    return unsubscribe;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loaded]);
+
+  function updateJob(jobId: string, updates: Partial<ScanJob>) {
+    setJobs((prev) => prev.map((j) => (j.id === jobId ? { ...j, ...updates } : j)));
+  }
+
+  // Keep executeScan in a ref so useCallbacks always call the latest version.
+  executeScanRef.current = async function executeScan(job: ScanJob) {
+    updateJob(job.id, { status: 'searching' });
+
+    try {
+      let results: EnrichedBook[];
+
+      if (job.type === 'text') {
+        const response = await api.get<EnrichedBook[]>('/books/search', {
+          params: { q: job.query },
+        });
+        results = response.data ?? [];
+      } else {
+        const formData = new FormData();
+        if (Platform.OS === 'web') {
+          // On web, imageUri is a blob URL or the File was already lost.
+          // For web, we store the File object reference separately — but since
+          // web doesn't persist the queue, this path only runs for live scans.
+          formData.append('file', job.imageUri as unknown as Blob, 'scan.jpg');
+        } else {
+          formData.append('file', {
+            uri: job.imageUri,
+            name: 'scan.jpg',
+            type: 'image/jpeg',
+          } as unknown as Blob);
+        }
+        const response = await api.post<EnrichedBook[]>('/scan', formData, {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          transformRequest: [
+            (data: FormData, headers: any) => {
+              if (Platform.OS === 'web') {
+                headers.delete('Content-Type');
+              } else {
+                headers.set('Content-Type', 'multipart/form-data');
+              }
+              return data;
+            },
+          ],
+        });
+        results = response.data ?? [];
+      }
+
+      if (results.length === 0) {
+        updateJob(job.id, { status: 'failed', error: 'no_results' });
+        showBanner({
+          message: t('noBooksFoundTitle'),
+          type: 'info',
+          duration: 4000,
+        });
+        return;
+      }
+
+      updateJob(job.id, { status: 'complete', results });
+      showBanner({
+        message: t('bookFound', { title: results[0].title }),
+        type: 'success',
+        actions: [
+          {
+            label: t('viewResults'),
+            onPress: () => setReviewingJobId(job.id),
+          },
+        ],
+      });
+    } catch {
+      updateJob(job.id, { status: 'failed', error: 'network_or_server' });
+      showBanner({
+        message: t('scanFailedTitle'),
+        type: 'error',
+        actions: [
+          { label: t('retryNow'), onPress: () => retryScan(job.id) },
+          { label: t('saveForLater'), onPress: () => queueForLater(job.id) },
+        ],
+        duration: 8000,
+      });
+    }
+  }
+
+  async function drainQueue() {
+    drainingRef.current = true;
+    try {
+      // Read the latest jobs from state via a callback to avoid stale closures.
+      let queuedJobs: ScanJob[] = [];
+      setJobs((prev) => {
+        queuedJobs = prev.filter((j) => j.status === 'queued' || j.status === 'pending');
+        return prev;
+      });
+
+      for (const job of queuedJobs) {
+        const netState = await NetInfo.fetch();
+        if (!netState.isConnected) break;
+        await executeScanRef.current(job);
+        // Delay between jobs to avoid API burst.
+        if (queuedJobs.indexOf(job) < queuedJobs.length - 1) {
+          await new Promise((r) => setTimeout(r, QUEUE_DRAIN_DELAY));
+        }
+      }
+    } finally {
+      drainingRef.current = false;
+    }
+  }
+
+  const startScan = useCallback(
+    async (type: ScanJobType, imageUri?: string, query?: string) => {
+      const job: ScanJob = {
+        id: uuidv4(),
+        type,
+        status: 'pending',
+        createdAt: Date.now(),
+        query,
+        imageUri,
+        retryCount: 0,
+      };
+
+      setJobs((prev) => [job, ...prev]);
+
+      const netState = await NetInfo.fetch();
+      if (!netState.isConnected) {
+        updateJob(job.id, { status: 'queued' });
+        showBanner({
+          message: t('savedOffline'),
+          type: 'info',
+          duration: 4000,
+        });
+        return;
+      }
+
+      await executeScanRef.current(job);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [showBanner, t],
+  );
+
+  // Keep jobs in a ref so retryScan can read the latest state synchronously.
+  const jobsRef = useRef(jobs);
+  jobsRef.current = jobs;
+
+  const retryScan = useCallback(
+    async (jobId: string) => {
+      const job = jobsRef.current.find((j) => j.id === jobId);
+      if (!job) return;
+
+      if (job.retryCount >= MAX_RETRIES) {
+        showBanner({
+          message: t('maxRetries'),
+          type: 'info',
+          duration: 4000,
+        });
+        updateJob(jobId, { status: 'queued' });
+        return;
+      }
+
+      const updated: ScanJob = {
+        ...job,
+        retryCount: job.retryCount + 1,
+        status: 'pending' as const,
+        error: undefined,
+      };
+      setJobs((prev) => prev.map((j) => (j.id === jobId ? updated : j)));
+      await executeScanRef.current(updated);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [showBanner, t],
+  );
+
+  const queueForLater = useCallback((jobId: string) => {
+    updateJob(jobId, { status: 'queued' });
+  }, []);
+
+  const reviewJob = useCallback((jobId: string) => {
+    setReviewingJobId(jobId);
+  }, []);
+
+  const dismissReview = useCallback(() => {
+    setReviewingJobId(null);
+  }, []);
+
+  const dismissJob = useCallback(
+    (jobId: string) => {
+      setJobs((prev) => prev.filter((j) => j.id !== jobId));
+      if (reviewingJobId === jobId) setReviewingJobId(null);
+
+      // Clean up persisted image if it exists.
+      if (Platform.OS !== 'web') {
+        const job = jobs.find((j) => j.id === jobId);
+        if (job?.imageUri) {
+          import('expo-file-system').then((fs) => {
+            fs.deleteAsync(job.imageUri!, { idempotent: true }).catch(() => {});
+          });
+        }
+      }
+    },
+    [jobs, reviewingJobId],
+  );
+
+  const handleSelectBook = useCallback(
+    async (book: EnrichedBook) => {
+      try {
+        await api.post('/wishlist', book);
+        if (reviewingJobId) {
+          dismissJob(reviewingJobId);
+        }
+        setReviewingJobId(null);
+        showBanner({
+          message: t('addedMessage', { title: book.title }),
+          type: 'success',
+          duration: 4000,
+        });
+      } catch {
+        showBanner({
+          message: t('couldNotSaveMessage'),
+          type: 'error',
+          duration: 4000,
+        });
+      }
+    },
+    [reviewingJobId, dismissJob, showBanner, t],
+  );
+
+  const reviewingJob = useMemo(
+    () => (reviewingJobId ? jobs.find((j) => j.id === reviewingJobId) ?? null : null),
+    [reviewingJobId, jobs],
+  );
+
+  const value = useMemo(
+    () => ({
+      jobs,
+      reviewingJob,
+      startScan,
+      retryScan,
+      queueForLater,
+      reviewJob,
+      dismissReview,
+      dismissJob,
+      handleSelectBook,
+    }),
+    [
+      jobs,
+      reviewingJob,
+      startScan,
+      retryScan,
+      queueForLater,
+      reviewJob,
+      dismissReview,
+      dismissJob,
+      handleSelectBook,
+    ],
+  );
+
+  return <ScanJobContext.Provider value={value}>{children}</ScanJobContext.Provider>;
+}

--- a/frontend/contexts/ScanJobContext.tsx
+++ b/frontend/contexts/ScanJobContext.tsx
@@ -58,7 +58,7 @@ export function ScanJobProvider({ children }: { children: React.ReactNode }) {
     (async () => {
       const persisted = await loadJobs();
       const restored = persisted.map((j) =>
-        j.status === 'searching' ? { ...j, status: 'pending' as const } : j,
+        j.status === 'searching' ? { ...j, status: 'pending' as const } : j
       );
       setJobs(restored);
       setLoaded(true);
@@ -155,7 +155,7 @@ export function ScanJobProvider({ children }: { children: React.ReactNode }) {
         duration: 8000,
       });
     }
-  }
+  };
 
   async function drainQueue() {
     drainingRef.current = true;
@@ -209,7 +209,7 @@ export function ScanJobProvider({ children }: { children: React.ReactNode }) {
       await executeScanRef.current(job);
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [showBanner, t],
+    [showBanner, t]
   );
 
   // Keep jobs in a ref so retryScan can read the latest state synchronously.
@@ -241,7 +241,7 @@ export function ScanJobProvider({ children }: { children: React.ReactNode }) {
       await executeScanRef.current(updated);
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [showBanner, t],
+    [showBanner, t]
   );
 
   const queueForLater = useCallback((jobId: string) => {
@@ -271,7 +271,7 @@ export function ScanJobProvider({ children }: { children: React.ReactNode }) {
         }
       }
     },
-    [jobs, reviewingJobId],
+    [jobs, reviewingJobId]
   );
 
   const handleSelectBook = useCallback(
@@ -295,12 +295,12 @@ export function ScanJobProvider({ children }: { children: React.ReactNode }) {
         });
       }
     },
-    [reviewingJobId, dismissJob, showBanner, t],
+    [reviewingJobId, dismissJob, showBanner, t]
   );
 
   const reviewingJob = useMemo(
-    () => (reviewingJobId ? jobs.find((j) => j.id === reviewingJobId) ?? null : null),
-    [reviewingJobId, jobs],
+    () => (reviewingJobId ? (jobs.find((j) => j.id === reviewingJobId) ?? null) : null),
+    [reviewingJobId, jobs]
   );
 
   const value = useMemo(
@@ -325,7 +325,7 @@ export function ScanJobProvider({ children }: { children: React.ReactNode }) {
       dismissReview,
       dismissJob,
       handleSelectBook,
-    ],
+    ]
   );
 
   return <ScanJobContext.Provider value={value}>{children}</ScanJobContext.Provider>;

--- a/frontend/hooks/useBanner.ts
+++ b/frontend/hooks/useBanner.ts
@@ -1,0 +1,6 @@
+import { useContext } from 'react';
+import { BannerContext } from '../contexts/BannerContext';
+
+export function useBanner() {
+  return useContext(BannerContext);
+}

--- a/frontend/hooks/useNetworkStatus.ts
+++ b/frontend/hooks/useNetworkStatus.ts
@@ -1,0 +1,14 @@
+import NetInfo from '@react-native-community/netinfo';
+import { useEffect, useState } from 'react';
+
+export function useNetworkStatus() {
+  const [isConnected, setIsConnected] = useState(true);
+
+  useEffect(() => {
+    return NetInfo.addEventListener((state) => {
+      setIsConnected(state.isConnected ?? true);
+    });
+  }, []);
+
+  return { isConnected };
+}

--- a/frontend/hooks/useScanJobs.ts
+++ b/frontend/hooks/useScanJobs.ts
@@ -1,0 +1,6 @@
+import { useContext } from 'react';
+import { ScanJobContext } from '../contexts/ScanJobContext';
+
+export function useScanJobs() {
+  return useContext(ScanJobContext);
+}

--- a/frontend/lib/scanJob.ts
+++ b/frontend/lib/scanJob.ts
@@ -1,0 +1,16 @@
+import type { EnrichedBook } from '../components/BookCandidatePicker';
+
+export type ScanJobType = 'image' | 'text';
+export type ScanJobStatus = 'pending' | 'searching' | 'complete' | 'failed' | 'queued';
+
+export interface ScanJob {
+  id: string;
+  type: ScanJobType;
+  status: ScanJobStatus;
+  createdAt: number;
+  query?: string;
+  imageUri?: string;
+  results?: EnrichedBook[];
+  error?: string;
+  retryCount: number;
+}

--- a/frontend/lib/scanJobStorage.ts
+++ b/frontend/lib/scanJobStorage.ts
@@ -1,0 +1,49 @@
+import { Platform } from 'react-native';
+import type { ScanJob } from './scanJob';
+
+const STORAGE_KEY = 'scan_job_queue';
+
+// Web: in-memory only (no offline persistence needed).
+const _webStore = new Map<string, string>();
+
+async function getStorage() {
+  if (Platform.OS === 'web') {
+    return {
+      getItem: (key: string) => _webStore.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        _webStore.set(key, value);
+      },
+      removeItem: (key: string) => {
+        _webStore.delete(key);
+      },
+    };
+  }
+  const AsyncStorage = (await import('@react-native-async-storage/async-storage')).default;
+  return AsyncStorage;
+}
+
+export async function saveJobs(jobs: ScanJob[]): Promise<void> {
+  const storage = await getStorage();
+  // Strip results from persisted jobs to keep storage size small.
+  // Results are only useful for the current session.
+  const stripped = jobs.map((j) => ({ ...j, results: undefined }));
+  storage.setItem(STORAGE_KEY, JSON.stringify(stripped));
+}
+
+export async function loadJobs(): Promise<ScanJob[]> {
+  try {
+    const storage = await getStorage();
+    const raw = await storage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed;
+  } catch {
+    return [];
+  }
+}
+
+export async function clearJobs(): Promise<void> {
+  const storage = await getStorage();
+  storage.removeItem(STORAGE_KEY);
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,12 +9,15 @@
       "version": "0.1.0",
       "dependencies": {
         "@expo/vector-icons": "^15.0.2",
+        "@react-native-async-storage/async-storage": "2.2.0",
+        "@react-native-community/netinfo": "11.5.2",
         "@sentry/react-native": "~7.11.0",
         "@tanstack/react-query": "^5.59.0",
         "axios": "^1.14.0",
         "expo": "^55.0.9",
         "expo-auth-session": "~55.0.10",
         "expo-camera": "~55.0.11",
+        "expo-file-system": "~55.0.12",
         "expo-router": "~55.0.8",
         "expo-secure-store": "~55.0.9",
         "expo-status-bar": "~55.0.4",
@@ -27,13 +30,15 @@
         "react-native": "0.83.4",
         "react-native-safe-area-context": "~5.6.2",
         "react-native-screens": "~4.23.0",
-        "react-native-web": "^0.21.0"
+        "react-native-web": "^0.21.0",
+        "uuid": "^13.0.0"
       },
       "devDependencies": {
         "@babel/core": "^7.24.0",
         "@react-native-community/cli": "^20.1.3",
         "@testing-library/react-native": "^13.3.3",
         "@types/react": "~19.2.10",
+        "@types/uuid": "^10.0.0",
         "eslint": "^8.57.0",
         "eslint-config-expo": "~55.0.0",
         "eslint-plugin-react-native-a11y": "^3.3.0",
@@ -3320,6 +3325,18 @@
         }
       }
     },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
+    },
     "node_modules/@react-native-community/cli": {
       "version": "20.1.3",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-20.1.3.tgz",
@@ -3779,6 +3796,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@react-native-community/netinfo": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-11.5.2.tgz",
+      "integrity": "sha512-/g0m65BtX9HU+bPiCH2517bOHpEIUsGrWFXDzi1a5nNKn5KujQgm04WhL7/OSXWKHyrT8VVtUoJA0XKRxueBpQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": ">=0.59"
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -4755,6 +4782,13 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -10366,6 +10400,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -12663,6 +12706,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -16838,12 +16893,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {
@@ -17193,6 +17252,15 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/xcode/node_modules/uuid": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/xml-name-validator": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,12 +14,15 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.2",
+    "@react-native-async-storage/async-storage": "2.2.0",
+    "@react-native-community/netinfo": "11.5.2",
     "@sentry/react-native": "~7.11.0",
     "@tanstack/react-query": "^5.59.0",
     "axios": "^1.14.0",
     "expo": "^55.0.9",
     "expo-auth-session": "~55.0.10",
     "expo-camera": "~55.0.11",
+    "expo-file-system": "~55.0.12",
     "expo-router": "~55.0.8",
     "expo-secure-store": "~55.0.9",
     "expo-status-bar": "~55.0.4",
@@ -32,13 +35,15 @@
     "react-native": "0.83.4",
     "react-native-safe-area-context": "~5.6.2",
     "react-native-screens": "~4.23.0",
-    "react-native-web": "^0.21.0"
+    "react-native-web": "^0.21.0",
+    "uuid": "^13.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.24.0",
     "@react-native-community/cli": "^20.1.3",
     "@testing-library/react-native": "^13.3.3",
     "@types/react": "~19.2.10",
+    "@types/uuid": "^10.0.0",
     "eslint": "^8.57.0",
     "eslint-config-expo": "~55.0.0",
     "eslint-plugin-react-native-a11y": "^3.3.0",

--- a/frontend/src/i18n/locales/en/components.json
+++ b/frontend/src/i18n/locales/en/components.json
@@ -12,5 +12,8 @@
   "themeToggle": {
     "toDark": "Switch to dark mode",
     "toLight": "Switch to light mode"
+  },
+  "inAppBanner": {
+    "dismiss": "Dismiss"
   }
 }

--- a/frontend/src/i18n/locales/en/scan.json
+++ b/frontend/src/i18n/locales/en/scan.json
@@ -29,5 +29,14 @@
   "scanUnavailableMessage": "Cover scanning is temporarily unavailable. Try searching by title instead.",
   "flipCamera": "Flip",
   "flipCameraA11y": "Flip camera",
-  "takePhoto": "Scan Book Cover"
+  "takePhoto": "Scan Book Cover",
+  "searchingInBackground": "Searching in background…",
+  "bookFound": "Book found: {{title}}",
+  "viewResults": "View",
+  "retryNow": "Retry",
+  "saveForLater": "Save for Later",
+  "savedOffline": "Saved for when you're back online",
+  "processingQueue": "Processing saved scan…",
+  "maxRetries": "Maximum retries reached. Saved for later.",
+  "noBooksFound": "No books found"
 }


### PR DESCRIPTION
## Summary
- **Background search**: Camera returns to idle immediately after capture; scan runs in background via new `ScanJobContext`
- **In-app notifications**: Slide-down `InAppBanner` shows results/errors from any tab with action buttons (View, Retry, Save for Later)
- **Offline queue**: Scans auto-queue when offline and drain when connectivity returns (via `@react-native-community/netinfo`)
- **Retry logic**: Failed scans offer retry (max 3 attempts) or save-for-later; queued jobs persist via `AsyncStorage`
- **Global book picker**: `BookCandidatePicker` lifted to root layout so results can be reviewed from any screen

## New files
| File | Purpose |
|------|---------|
| `lib/scanJob.ts` | ScanJob types |
| `lib/scanJobStorage.ts` | AsyncStorage persistence |
| `contexts/ScanJobContext.tsx` | Core background scan state management |
| `contexts/BannerContext.tsx` | Banner display state |
| `components/InAppBanner.tsx` | Animated notification banner |
| `hooks/useScanJobs.ts`, `useBanner.ts`, `useNetworkStatus.ts` | Convenience hooks |

## New dependencies
`@react-native-async-storage/async-storage`, `@react-native-community/netinfo`, `expo-file-system`, `uuid`

## Test plan
- [x] All 175 frontend tests pass (`npx jest --coverage`)
- [ ] Manual: take photo → camera returns to idle → banner shows result → tap "View" → picker opens
- [ ] Manual: airplane mode → take photo → "Saved for when you're back online" banner → enable wifi → auto-processes
- [ ] Manual: force API error → banner with "Retry" / "Save for Later" → both work
- [ ] Manual: navigate to different tab during search → banner still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)