### PR TITLE
feat: use buffingchi.com domain and add dev/prod API separation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,5 +15,5 @@ jobs:
     with:
       service-name: 'bookshelf-api'
       service-id: 'srv-d6vkel7fte5s73du7fc0'
-      zap-target-url: 'https://bookshelf-api-rxp3.onrender.com'
+      zap-target-url: 'https://bookshelfapi.buffingchi.com'
     secrets: inherit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -144,7 +144,7 @@ jobs:
       - name: ZAP Full Scan
         uses: zaproxy/action-full-scan@v0.13.0
         with:
-          target: 'https://bookshelf-api-rxp3.onrender.com'
+          target: 'https://bookshelfapi.buffingchi.com'
           rules_file_name: '.zap/rules.tsv'
           cmd_options: '-z "-config scanner.attackStrength=LOW"'
           allow_issue_writing: false

--- a/.gitignore
+++ b/.gitignore
@@ -68,5 +68,13 @@ frontend/ios/*.xcarchive
 frontend/ios/Bookshelf.xcworkspace/xcuserdata/
 frontend/ios/.xcode.env.local
 
+# Android bare workflow — commit the project, ignore build artifacts
+frontend/android/app/build/
+frontend/android/build/
+frontend/android/.gradle/
+frontend/android/app/upload-keystore.jks
+*.jks
+*.keystore
+
 # Claude Code local overrides (personal, not shared)
 .claude/settings.local.json

--- a/backend/tests/unit/test_config.py
+++ b/backend/tests/unit/test_config.py
@@ -60,9 +60,9 @@ class TestCorsOriginsValidator:
     def test_accepts_valid_origins(self):
         s = Settings(
             database_url="postgresql+asyncpg://u:p@localhost/db",
-            cors_origins=["https://example.onrender.com", "http://localhost:8081"],
+            cors_origins=["https://example.buffingchi.com", "http://localhost:8081"],
         )
-        assert "https://example.onrender.com" in s.cors_origins
+        assert "https://example.buffingchi.com" in s.cors_origins
 
     def test_accepts_empty_origins(self):
         s = Settings(

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -26,7 +26,7 @@
   <p>We do not collect analytics, advertising identifiers, location data, contacts, or any other personal information beyond account and reading data.</p>
 
   <h2>Data Storage</h2>
-  <p>Your data is stored on servers hosted by Render (render.com). Authentication tokens are stored securely on your device using iOS Secure Enclave via Keychain.</p>
+  <p>Your data is stored on secure cloud servers protected by Cloudflare. Authentication tokens are stored securely on your device using iOS Secure Enclave via Keychain.</p>
 
   <h2>Third Parties</h2>
   <p>We use the Open Library API and OpenAI API to look up book information by ISBN. No personal data is shared with these services — only ISBNs are transmitted during lookups.</p>

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,6 +1,7 @@
-EXPO_PUBLIC_API_URL=https://bookshelfapi.buffingchi.com
+# Dev: https://bookshelfapi-dev.buffingchi.com | Prod: https://bookshelfapi.buffingchi.com
+EXPO_PUBLIC_API_URL=https://bookshelfapi-dev.buffingchi.com
 EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=648904540482-adeo13bqnptm6044dkg0168n7706lhnt.apps.googleusercontent.com
 EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID=648904540482-07ckrnvv97q5if96fh3sjjj2kmet306n.apps.googleusercontent.com
-EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID=your-android-client-id.apps.googleusercontent.com
+EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID=your-android-client-id-here.apps.googleusercontent.com
 EXPO_PUBLIC_SENTRY_DSN=your-sentry-dsn-here
 EXPO_PUBLIC_ENVIRONMENT=development

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,5 +1,6 @@
 EXPO_PUBLIC_API_URL=https://bookshelfapi.buffingchi.com
 EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=648904540482-adeo13bqnptm6044dkg0168n7706lhnt.apps.googleusercontent.com
 EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID=648904540482-07ckrnvv97q5if96fh3sjjj2kmet306n.apps.googleusercontent.com
+EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID=648904540482-7jmciikkisu5ncs6ftl2e9ps3jal5krp.apps.googleusercontent.com
 EXPO_PUBLIC_SENTRY_DSN=https://8d7985b74e3df0be133eb2d78d27a8c3@o4511129011093504.ingest.us.sentry.io/4511129213927424
 EXPO_PUBLIC_ENVIRONMENT=production

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -43,7 +43,9 @@
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
       },
-      "package": "com.bookshelf.app"
+      "package": "com.buffingchi.bookshelf",
+      "versionCode": 1,
+      "permissions": ["CAMERA"]
     },
     "web": {
       "favicon": "./assets/favicon.png",

--- a/frontend/eas.json
+++ b/frontend/eas.json
@@ -9,11 +9,16 @@
       "ios": {
         "simulator": true
       },
+      "android": {
+        "buildType": "apk"
+      },
       "env": {
-        "EXPO_PUBLIC_API_URL": "https://bookshelfapi.buffingchi.com",
+        "EXPO_PUBLIC_API_URL": "https://bookshelfapi-dev.buffingchi.com",
         "EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID": "648904540482-adeo13bqnptm6044dkg0168n7706lhnt.apps.googleusercontent.com",
         "EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID": "648904540482-07ckrnvv97q5if96fh3sjjj2kmet306n.apps.googleusercontent.com",
-        "EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID": "REPLACE_ME"
+        "EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID": "648904540482-7jmciikkisu5ncs6ftl2e9ps3jal5krp.apps.googleusercontent.com",
+        "EXPO_PUBLIC_SENTRY_DSN": "https://8d7985b74e3df0be133eb2d78d27a8c3@o4511129011093504.ingest.us.sentry.io/4511129213927424",
+        "EXPO_PUBLIC_ENVIRONMENT": "development"
       }
     },
     "preview": {
@@ -22,11 +27,16 @@
         "resourceClass": "m-medium",
         "simulator": false
       },
+      "android": {
+        "buildType": "apk"
+      },
       "env": {
-        "EXPO_PUBLIC_API_URL": "https://bookshelfapi.buffingchi.com",
+        "EXPO_PUBLIC_API_URL": "https://bookshelfapi-dev.buffingchi.com",
         "EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID": "648904540482-adeo13bqnptm6044dkg0168n7706lhnt.apps.googleusercontent.com",
         "EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID": "648904540482-07ckrnvv97q5if96fh3sjjj2kmet306n.apps.googleusercontent.com",
-        "EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID": "REPLACE_ME"
+        "EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID": "648904540482-7jmciikkisu5ncs6ftl2e9ps3jal5krp.apps.googleusercontent.com",
+        "EXPO_PUBLIC_SENTRY_DSN": "https://8d7985b74e3df0be133eb2d78d27a8c3@o4511129011093504.ingest.us.sentry.io/4511129213927424",
+        "EXPO_PUBLIC_ENVIRONMENT": "preview"
       }
     },
     "production": {
@@ -34,11 +44,14 @@
       "ios": {
         "resourceClass": "m-medium"
       },
+      "android": {},
       "env": {
         "EXPO_PUBLIC_API_URL": "https://bookshelfapi.buffingchi.com",
         "EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID": "648904540482-adeo13bqnptm6044dkg0168n7706lhnt.apps.googleusercontent.com",
         "EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID": "648904540482-07ckrnvv97q5if96fh3sjjj2kmet306n.apps.googleusercontent.com",
-        "EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID": "REPLACE_ME"
+        "EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID": "648904540482-7jmciikkisu5ncs6ftl2e9ps3jal5krp.apps.googleusercontent.com",
+        "EXPO_PUBLIC_SENTRY_DSN": "https://8d7985b74e3df0be133eb2d78d27a8c3@o4511129011093504.ingest.us.sentry.io/4511129213927424",
+        "EXPO_PUBLIC_ENVIRONMENT": "production"
       }
     }
   }

--- a/render.yaml
+++ b/render.yaml
@@ -56,7 +56,7 @@ services:
         value: 'max-age=31536000; includeSubDomains'
       - path: /*
         name: Content-Security-Policy
-        value: "default-src 'self'; img-src 'self' https: data:; connect-src 'self' https://bookshelfapi.buffingchi.com; style-src 'self' 'unsafe-inline'; script-src 'self'"
+        value: "default-src 'self'; img-src 'self' https: data:; connect-src 'self' https://bookshelfapi-dev.buffingchi.com; style-src 'self' 'unsafe-inline'; script-src 'self'"
       - path: /*
         name: Cache-Control
         value: no-cache
@@ -65,13 +65,13 @@ services:
         value: 'public, max-age=31536000, immutable'
     envVars:
       - key: EXPO_PUBLIC_API_URL
-        value: https://bookshelfapi.buffingchi.com
+        value: https://bookshelfapi-dev.buffingchi.com
       - key: EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID
         sync: false
       - key: EXPO_PUBLIC_SENTRY_DSN
         sync: false
       - key: EXPO_PUBLIC_ENVIRONMENT
-        value: production
+        value: development
 
 databases:
   - name: bookshelf-db


### PR DESCRIPTION
## Summary
- Remove all hardcoded `onrender.com` URLs from CI workflows (deploy.yml, security.yml) and backend tests
- Add dev/prod API URL separation: dev/preview builds → `bookshelfapi-dev.buffingchi.com`, production → `bookshelfapi.buffingchi.com`
- Update render.yaml web service to use dev API URL and `development` environment (matches dev branch deployment)
- Update privacy docs to be provider-neutral (Cloudflare instead of Render branding)
- Backfill Android client IDs and EAS profile config for consistency

## Files changed
- `.github/workflows/deploy.yml` — ZAP target → buffingchi.com
- `.github/workflows/security.yml` — ZAP target → buffingchi.com
- `.gitignore` — Android build artifact ignores
- `backend/tests/unit/test_config.py` — example domain updated
- `docs/privacy.html` — provider-neutral hosting description
- `frontend/.env.example` — dev API URL + comment documenting both
- `frontend/.env.production` — add Android client ID
- `frontend/app.json` — Android package + permissions
- `frontend/eas.json` — dev/preview → dev API, production → prod API
- `render.yaml` — web service env/CSP → dev API

## Not changed (intentionally)
- `set-sentry-dsn.yml` — uses Render management API (api.render.com), not an app URL
- `backend/app/core/config.py` — already environment-aware
- `frontend/lib/api.ts` — already reads EXPO_PUBLIC_API_URL dynamically

## Test plan
- [x] `grep -r "onrender.com"` returns zero results
- [x] Backend config tests pass (10/10)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)