### PR TITLE
feat(e2e): full scan-to-wishlist happy path Maestro flows

### DIFF
--- a/frontend/.maestro/scan-to-wishlist-camera.yaml
+++ b/frontend/.maestro/scan-to-wishlist-camera.yaml
@@ -1,0 +1,77 @@
+appId: com.buffingchi.bookshelf
+name: Happy path — camera capture → select book → verify wishlist
+tags:
+  - e2e
+  - happy-path
+  - wishlist
+  - camera
+---
+# FULL HAPPY PATH (CAMERA VARIANT): capture a book cover, select from results,
+# confirm it's in the wishlist.
+#
+# Prerequisites:
+#   - App is launched and user is logged in
+#   - Backend running with valid OpenAI, Google Books, and OpenLibrary API keys
+#   - A physical book cover visible to the simulator camera, OR a simulator with
+#     a custom camera feed image (Xcode > Simulator > Features > Camera)
+#   - Network connectivity available
+#
+# ⚠️  This flow is NON-DETERMINISTIC — results depend on what the Vision API
+#     identifies from the camera feed. For CI use scan-to-wishlist-happy-path.yaml
+#     (text search variant) instead.
+
+# ── Step 1: Navigate to scan tab (camera mode is the default) ────────────────
+- tapOn:
+    text: 'Camera'
+
+# Verify camera controls are visible
+- assertVisible:
+    label: 'Capture book cover'
+    timeout: 5000
+
+# ── Step 2: Capture a photo ──────────────────────────────────────────────────
+- tapOn:
+    label: 'Capture book cover'
+
+# Camera controls should remain visible (capture is non-blocking)
+- assertVisible:
+    label: 'Capture book cover'
+
+# ── Step 3: Wait for results ─────────────────────────────────────────────────
+# The full pipeline: image upload → OpenAI Vision → enrichment → results.
+# This can take 10-20 seconds depending on API response times.
+- assertVisible:
+    text: 'Book found:.*'
+    timeout: 30000
+
+# ── Step 4: Tap "View" to open the BookCandidatePicker ──────────────────────
+- tapOn:
+    label: 'View'
+    timeout: 5000
+
+# ── Step 5: Verify the picker modal is showing ──────────────────────────────
+- assertVisible:
+    text: 'Which book is this?'
+    timeout: 3000
+
+# ── Step 6: Select the first book candidate ──────────────────────────────────
+# We can't predict which book the Vision API identifies, so tap the first
+# candidate card using a broad pattern.
+- tapOn:
+    label: 'Select .*'
+    index: 0
+    timeout: 5000
+
+# ── Step 7: Wait for success banner ─────────────────────────────────────────
+- assertVisible:
+    text: '.*added to your wishlist.*'
+    timeout: 10000
+
+# ── Step 8: Navigate to wishlist and verify ──────────────────────────────────
+- tapOn:
+    text: 'Wishlist'
+
+# Wishlist should not be empty — at least one book was just added
+- assertNotVisible:
+    text: 'Your wishlist is empty.*'
+    timeout: 10000

--- a/frontend/.maestro/scan-to-wishlist-happy-path.yaml
+++ b/frontend/.maestro/scan-to-wishlist-happy-path.yaml
@@ -1,0 +1,86 @@
+appId: com.buffingchi.bookshelf
+name: Happy path — text search → select book → verify wishlist
+tags:
+  - e2e
+  - happy-path
+  - wishlist
+  - scan
+---
+# FULL HAPPY PATH: search for a book, select from results, confirm it's in the wishlist.
+#
+# Prerequisites:
+#   - App is launched and user is logged in
+#   - Backend is running with valid Google Books + OpenLibrary API keys
+#   - Network connectivity available
+#
+# Uses text search (not camera) for deterministic, CI-friendly results.
+# For the camera-capture variant see scan-to-wishlist-camera.yaml.
+
+# ── Step 1: Navigate to scan tab ─────────────────────────────────────────────
+- tapOn:
+    text: 'Camera'
+
+# ── Step 2: Switch to text search mode ───────────────────────────────────────
+- tapOn:
+    label: 'Text search mode'
+
+- assertVisible:
+    label: 'Book title or author search'
+
+# ── Step 3: Search for a well-known book ─────────────────────────────────────
+- tapOn:
+    label: 'Book title or author search'
+- inputText: 'Dune by Frank Herbert'
+- tapOn:
+    label: 'Search for book'
+
+# ── Step 4: Wait for results banner ──────────────────────────────────────────
+# The API call chain (Google Books + OpenLibrary enrichment) can take several
+# seconds. Wait up to 15s for the "Book found" success banner.
+- assertVisible:
+    text: '.*Dune.*'
+    timeout: 15000
+
+# ── Step 5: Tap "View" to open the BookCandidatePicker modal ────────────────
+- tapOn:
+    label: 'View'
+    timeout: 5000
+
+# ── Step 6: Verify the picker modal is showing candidates ───────────────────
+- assertVisible:
+    text: 'Which book is this?'
+    timeout: 3000
+
+# ── Step 7: Select the first book candidate ──────────────────────────────────
+# The candidate card's accessibility label follows the pattern:
+#   "Select {title} by {author}"
+# Use a regex to match any candidate with "Dune" in the label.
+- tapOn:
+    label: 'Select Dune.*'
+    timeout: 5000
+
+# ── Step 8: Wait for "added to wishlist" success banner ──────────────────────
+- assertVisible:
+    text: '.*added to your wishlist.*'
+    timeout: 10000
+
+# ── Step 9: Navigate to wishlist tab to confirm ─────────────────────────────
+- tapOn:
+    text: 'Wishlist'
+
+# ── Step 10: Verify the book appears in the wishlist ─────────────────────────
+- assertVisible:
+    text: 'Dune'
+    timeout: 10000
+
+- assertVisible:
+    text: 'Frank Herbert'
+    timeout: 3000
+    optional: true
+
+# ── Step 11: Clean up — remove the book from wishlist ────────────────────────
+# This prevents test pollution on repeated runs.
+- tapOn:
+    label: 'Remove Dune.*'
+    optional: true
+    timeout: 3000


### PR DESCRIPTION
## Summary
- Adds two Maestro E2E flows covering the **complete user journey** from book discovery to wishlist confirmation
- **Text search variant** (`scan-to-wishlist-happy-path.yaml`): deterministic, CI-friendly — search "Dune" → wait for results banner → tap "View" → select book from picker → verify success banner → navigate to wishlist → confirm book appears → cleanup
- **Camera capture variant** (`scan-to-wishlist-camera.yaml`): requires real Vision API — capture photo → wait for enrichment (30s timeout) → select first candidate → verify wishlist — non-deterministic, for manual testing

## Test plan
- [ ] Run `maestro test frontend/.maestro/scan-to-wishlist-happy-path.yaml` on simulator with backend running
- [ ] Verify text search flow completes end-to-end: search → results → select → wishlist confirmation
- [ ] Verify cleanup step removes the book after verification (idempotent for repeat runs)
- [ ] Run camera variant manually on device with a book cover visible

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)