### PR TITLE
fix: use Directory instead of File for scan-queue destination (#174)

### DIFF
--- a/frontend/__tests__/unit/ScanScreen.test.tsx
+++ b/frontend/__tests__/unit/ScanScreen.test.tsx
@@ -42,11 +42,22 @@ jest.mock('expo-camera', () => {
 
 const mockFileCopy = jest.fn();
 const mockFileCreate = jest.fn();
+const mockDirCreate = jest.fn();
 
 jest.mock('expo-file-system', () => ({
   Paths: { document: 'file:///docs' },
+  Directory: jest.fn().mockImplementation((...args: unknown[]) => {
+    const parts = args.map((a) =>
+      typeof a === 'object' && a !== null && 'uri' in a ? (a as { uri: string }).uri : String(a)
+    );
+    return {
+      uri: parts.join('/'),
+      exists: true,
+      create: mockDirCreate,
+    };
+  }),
   File: jest.fn().mockImplementation((...args: unknown[]) => {
-    // Mimic expo-file-system File: resolve uri from parent (string or File) + name
+    // Mimic expo-file-system File: resolve uri from parent (string or File/Directory) + name
     const parts = args.map((a) =>
       typeof a === 'object' && a !== null && 'uri' in a ? (a as { uri: string }).uri : String(a)
     );
@@ -395,26 +406,22 @@ describe('ScanScreen — Sentry logging', () => {
 describe('ScanScreen — scan-queue directory handling', () => {
   it('creates scan-queue directory when it does not exist', async () => {
     const FileSystem = require('expo-file-system');
-    // Override File mock to return exists: false for directory
-    let callCount = 0;
-    FileSystem.File.mockImplementation((...args: unknown[]) => {
-      callCount++;
+    // Override Directory mock to return exists: false
+    FileSystem.Directory.mockImplementationOnce((...args: unknown[]) => {
       const parts = args.map((a: unknown) =>
         typeof a === 'object' && a !== null && 'uri' in a ? (a as { uri: string }).uri : String(a)
       );
       return {
         uri: parts.join('/'),
-        // First File() call is the destDir — simulate it not existing
-        exists: callCount !== 1,
-        create: mockFileCreate,
-        copy: mockFileCopy,
+        exists: false,
+        create: mockDirCreate,
       };
     });
 
     mockTakePictureAsync.mockResolvedValue({ uri: 'file://test.jpg' });
     const { getByLabelText } = render(<ScanScreen />);
     await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
-    expect(mockFileCreate).toHaveBeenCalled();
+    expect(mockDirCreate).toHaveBeenCalled();
   });
 
   it('skips directory creation when scan-queue already exists', async () => {
@@ -422,6 +429,6 @@ describe('ScanScreen — scan-queue directory handling', () => {
     const { getByLabelText } = render(<ScanScreen />);
     await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
     // Default mock returns exists: true, so create should not be called
-    expect(mockFileCreate).not.toHaveBeenCalled();
+    expect(mockDirCreate).not.toHaveBeenCalled();
   });
 });

--- a/frontend/app/(tabs)/scan.tsx
+++ b/frontend/app/(tabs)/scan.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useState } from 'react';
 import { Platform, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
 import { CameraView, useCameraPermissions } from 'expo-camera';
-import { File, Paths } from 'expo-file-system';
+import { Directory, File, Paths } from 'expo-file-system';
 import { useTranslation } from 'react-i18next';
 
 import { Sentry } from '../../lib/sentry';
@@ -65,7 +65,7 @@ export default function ScanScreen() {
       }
 
       // Copy temp file to persistent document directory.
-      const destDir = new File(Paths.document, 'scan-queue');
+      const destDir = new Directory(Paths.document, 'scan-queue');
       if (!destDir.exists) {
         destDir.create();
       }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12630,9 +12630,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12652,9 +12649,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -12676,9 +12670,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12698,9 +12689,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,


### PR DESCRIPTION
Camera capture failed because `new File(...)` created an empty file
named `scan-queue` instead of a directory, causing the copy to fail.
Switched to `new Directory(...)` and updated test mocks accordingly.

Closes #174

https://claude.ai/code/session_01TxDgK6yh3VevYkpZzsRK76