### PR TITLE
fix: camera capture silently fails — heal stale scan-queue + visible errors (#174)

### DIFF
--- a/frontend/__tests__/integration/ScanCaptureFlow.test.tsx
+++ b/frontend/__tests__/integration/ScanCaptureFlow.test.tsx
@@ -1,0 +1,176 @@
+// Integration test for the camera-capture → scan handoff. Uses the REAL
+// BannerProvider + InAppBanner so we assert that users actually see an error
+// message on the screen when the capture pipeline fails — which is the class
+// of silent-failure bug that issue #174 was a symptom of.
+//
+// expo-camera and expo-file-system are mocked (no native module in jest), but
+// the i18n layer, BannerContext, InAppBanner, and useScanJobs are REAL.
+import React from 'react';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+
+import ScanScreen from '../../app/(tabs)/scan';
+import { BannerProvider } from '../../contexts/BannerContext';
+import { InAppBanner } from '../../components/InAppBanner';
+
+// ── expo-camera mock ────────────────────────────────────────────────────────
+const mockTakePictureAsync = jest.fn();
+jest.mock('expo-camera', () => {
+  const React = require('react');
+  const MockCameraView = React.forwardRef(
+    ({ children }: { children: React.ReactNode }, ref: React.Ref<unknown>) => {
+      React.useImperativeHandle(ref, () => ({ takePictureAsync: mockTakePictureAsync }));
+      return <>{children}</>;
+    }
+  );
+  MockCameraView.displayName = 'CameraView';
+  return {
+    CameraView: MockCameraView,
+    useCameraPermissions: () => [{ granted: true }, jest.fn()],
+  };
+});
+
+// ── expo-file-system mock (configurable per test) ───────────────────────────
+const mockDirCreate = jest.fn();
+const mockFileCopy = jest.fn();
+jest.mock('expo-file-system', () => ({
+  Paths: { document: 'file:///docs' },
+  Directory: jest.fn().mockImplementation((...args: unknown[]) => {
+    const parts = args.map((a) =>
+      typeof a === 'object' && a !== null && 'uri' in a ? (a as { uri: string }).uri : String(a)
+    );
+    return { uri: parts.join('/'), exists: true, create: mockDirCreate };
+  }),
+  File: jest.fn().mockImplementation((...args: unknown[]) => {
+    const parts = args.map((a) =>
+      typeof a === 'object' && a !== null && 'uri' in a ? (a as { uri: string }).uri : String(a)
+    );
+    return {
+      uri: parts.join('/'),
+      exists: false,
+      copy: mockFileCopy,
+      delete: jest.fn(),
+      create: jest.fn(),
+    };
+  }),
+}));
+
+// ── useScanJobs mock (we don't need the real scan orchestrator here — we're
+//    verifying the capture-side banner surfaces, not the API layer). ────────
+const mockStartScan = jest.fn();
+jest.mock('../../hooks/useScanJobs', () => ({
+  useScanJobs: () => ({
+    jobs: [],
+    reviewingJob: null,
+    startScan: mockStartScan,
+    retryScan: jest.fn(),
+    queueForLater: jest.fn(),
+    reviewJob: jest.fn(),
+    dismissReview: jest.fn(),
+    dismissJob: jest.fn(),
+    handleSelectBook: jest.fn(),
+  }),
+}));
+
+jest.mock('../../hooks/useTheme', () => ({
+  useTheme: () => ({
+    theme: {
+      colors: {
+        background: '#fff',
+        surface: '#f5f5f5',
+        border: '#ccc',
+        text: '#000',
+        textSecondary: '#888',
+        primary: '#007AFF',
+        success: '#22c55e',
+        error: '#ef4444',
+      },
+      typography: { fontSizeBase: 16 },
+      spacing: { md: 16 },
+    },
+  }),
+}));
+
+jest.mock('../../lib/sentry', () => ({
+  Sentry: { captureException: jest.fn(), addBreadcrumb: jest.fn() },
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+function renderWithBanner() {
+  return render(
+    <BannerProvider>
+      <ScanScreen />
+      <InAppBanner />
+    </BannerProvider>
+  );
+}
+
+describe('Scan capture flow — integration with real BannerProvider', () => {
+  it('renders an error banner on screen when Directory.create throws', async () => {
+    // Simulate the exact failure mode from this bug: create() throws because a
+    // stale file already exists at the path.
+    mockDirCreate.mockImplementationOnce(() => {
+      throw new Error('EEXIST: file with same path exists');
+    });
+    mockTakePictureAsync.mockResolvedValue({ uri: 'file://tmp/photo.jpg' });
+
+    const utils = renderWithBanner();
+    await act(async () => fireEvent.press(utils.getByLabelText('Capture book cover')));
+
+    // The real BannerProvider + InAppBanner must now show the error text.
+    await waitFor(() => {
+      expect(utils.getByText('Something went wrong. Please try again.')).toBeTruthy();
+    });
+    // Scan must NOT have started.
+    expect(mockStartScan).not.toHaveBeenCalled();
+  });
+
+  it('renders an error banner when File.copy throws (disk full)', async () => {
+    mockFileCopy.mockImplementationOnce(() => {
+      throw new Error('ENOSPC: no space left on device');
+    });
+    mockTakePictureAsync.mockResolvedValue({ uri: 'file://tmp/photo.jpg' });
+
+    const utils = renderWithBanner();
+    await act(async () => fireEvent.press(utils.getByLabelText('Capture book cover')));
+
+    await waitFor(() => {
+      expect(utils.getByText('Something went wrong. Please try again.')).toBeTruthy();
+    });
+    expect(mockStartScan).not.toHaveBeenCalled();
+  });
+
+  it('banner has a Retry action that triggers another capture attempt', async () => {
+    // First attempt throws, second succeeds.
+    mockDirCreate.mockImplementationOnce(() => {
+      throw new Error('EEXIST');
+    });
+    mockTakePictureAsync.mockResolvedValue({ uri: 'file://tmp/photo.jpg' });
+
+    const utils = renderWithBanner();
+    await act(async () => fireEvent.press(utils.getByLabelText('Capture book cover')));
+
+    const retryButton = await waitFor(() => utils.getByLabelText('Retry'));
+    await act(async () => fireEvent.press(retryButton));
+
+    // After retry, the happy path runs and startScan fires.
+    await waitFor(() => expect(mockStartScan).toHaveBeenCalled());
+  });
+
+  it('happy path: no banner shown, scan started with a valid URI', async () => {
+    mockTakePictureAsync.mockResolvedValue({ uri: 'file://tmp/photo.jpg' });
+
+    const utils = renderWithBanner();
+    await act(async () => fireEvent.press(utils.getByLabelText('Capture book cover')));
+
+    await waitFor(() => expect(mockStartScan).toHaveBeenCalled());
+    expect(mockStartScan).toHaveBeenCalledWith(
+      'image',
+      expect.stringMatching(/^file:\/\/\/docs\/scan-queue\/\d+-\d+\.jpg$/)
+    );
+    // No error text on screen.
+    expect(utils.queryByText('Something went wrong. Please try again.')).toBeNull();
+  });
+});

--- a/frontend/__tests__/unit/ScanScreen.test.tsx
+++ b/frontend/__tests__/unit/ScanScreen.test.tsx
@@ -505,9 +505,7 @@ describe('ScanScreen — capture failure paths surface banners', () => {
     await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
 
     expect(mockStartScan).not.toHaveBeenCalled();
-    expect(mockShowBanner).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'error' })
-    );
+    expect(mockShowBanner).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
     expect(mockCaptureException).toHaveBeenCalledWith(
       expect.any(Error),
       expect.objectContaining({
@@ -525,9 +523,7 @@ describe('ScanScreen — capture failure paths surface banners', () => {
     await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
 
     expect(mockStartScan).not.toHaveBeenCalled();
-    expect(mockShowBanner).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'error' })
-    );
+    expect(mockShowBanner).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
     expect(mockCaptureException).toHaveBeenCalledWith(
       expect.any(Error),
       expect.objectContaining({
@@ -542,9 +538,7 @@ describe('ScanScreen — capture failure paths surface banners', () => {
     await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
 
     expect(mockStartScan).not.toHaveBeenCalled();
-    expect(mockShowBanner).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'error' })
-    );
+    expect(mockShowBanner).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
     expect(mockCaptureException).toHaveBeenCalledWith(
       expect.any(Error),
       expect.objectContaining({

--- a/frontend/__tests__/unit/ScanScreen.test.tsx
+++ b/frontend/__tests__/unit/ScanScreen.test.tsx
@@ -42,6 +42,7 @@ jest.mock('expo-camera', () => {
 
 const mockFileCopy = jest.fn();
 const mockFileCreate = jest.fn();
+const mockFileDelete = jest.fn();
 const mockDirCreate = jest.fn();
 
 jest.mock('expo-file-system', () => ({
@@ -63,9 +64,12 @@ jest.mock('expo-file-system', () => ({
     );
     return {
       uri: parts.join('/'),
-      exists: true,
+      // Default to `false` so the stale-file cleanup path is a no-op by default.
+      // Tests that simulate the pre-#174 corruption override this.
+      exists: false,
       create: mockFileCreate,
       copy: mockFileCopy,
+      delete: mockFileDelete,
     };
   }),
 }));
@@ -78,6 +82,15 @@ jest.mock('../../lib/sentry', () => ({
     captureException: (...args: unknown[]) => mockCaptureException(...args),
     addBreadcrumb: (...args: unknown[]) => mockAddBreadcrumb(...args),
   },
+}));
+
+const mockShowBanner = jest.fn();
+jest.mock('../../hooks/useBanner', () => ({
+  useBanner: () => ({
+    showBanner: mockShowBanner,
+    hideBanner: jest.fn(),
+    banner: null,
+  }),
 }));
 
 jest.mock('../../hooks/useTheme', () => ({
@@ -217,7 +230,7 @@ describe('ScanScreen — native capture flow', () => {
     await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
     expect(mockStartScan).toHaveBeenCalledWith(
       'image',
-      expect.stringContaining('file:///docs/scan-queue/')
+      expect.stringMatching(/^file:\/\/\/docs\/scan-queue\/\d+-\d+\.jpg$/)
     );
   });
 
@@ -376,7 +389,9 @@ describe('ScanScreen — Sentry logging', () => {
     await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
     expect(mockCaptureException).toHaveBeenCalledWith(
       copyError,
-      expect.objectContaining({ tags: { feature: 'camera-capture' } })
+      expect.objectContaining({
+        tags: expect.objectContaining({ feature: 'camera-capture' }),
+      })
     );
   });
 
@@ -401,34 +416,196 @@ describe('ScanScreen — Sentry logging', () => {
 });
 
 // ---------------------------------------------------------------------------
-// File system — directory creation
+// File system — scan-queue handling (every capture attempts create idempotently)
 // ---------------------------------------------------------------------------
 describe('ScanScreen — scan-queue directory handling', () => {
-  it('creates scan-queue directory when it does not exist', async () => {
+  it('always calls Directory.create with idempotent + intermediates', async () => {
+    mockTakePictureAsync.mockResolvedValue({ uri: 'file://test.jpg' });
+    const { getByLabelText } = render(<ScanScreen />);
+    await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
+    expect(mockDirCreate).toHaveBeenCalledWith({ intermediates: true, idempotent: true });
+  });
+
+  it('deletes a stale File at the scan-queue path before creating the Directory', async () => {
     const FileSystem = require('expo-file-system');
-    // Override Directory mock to return exists: false
-    FileSystem.Directory.mockImplementationOnce((...args: unknown[]) => {
+    // Override the first File() call (the stale-file check) to claim it exists.
+    // Subsequent File() calls (destFile, sourceFile) return exists: false as usual.
+    FileSystem.File.mockImplementationOnce((...args: unknown[]) => {
       const parts = args.map((a: unknown) =>
         typeof a === 'object' && a !== null && 'uri' in a ? (a as { uri: string }).uri : String(a)
       );
       return {
         uri: parts.join('/'),
-        exists: false,
-        create: mockDirCreate,
+        exists: true,
+        create: mockFileCreate,
+        copy: mockFileCopy,
+        delete: mockFileDelete,
       };
     });
 
     mockTakePictureAsync.mockResolvedValue({ uri: 'file://test.jpg' });
     const { getByLabelText } = render(<ScanScreen />);
     await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
+    // Healing: stale file deleted, directory created, scan proceeds.
+    expect(mockFileDelete).toHaveBeenCalled();
     expect(mockDirCreate).toHaveBeenCalled();
+    expect(mockStartScan).toHaveBeenCalled();
+    expect(mockShowBanner).not.toHaveBeenCalled();
   });
 
-  it('skips directory creation when scan-queue already exists', async () => {
+  it('skips delete when no stale File exists at scan-queue path', async () => {
+    // Default File mock returns exists: false → no delete should fire.
     mockTakePictureAsync.mockResolvedValue({ uri: 'file://test.jpg' });
     const { getByLabelText } = render(<ScanScreen />);
     await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
-    // Default mock returns exists: true, so create should not be called
-    expect(mockDirCreate).not.toHaveBeenCalled();
+    expect(mockFileDelete).not.toHaveBeenCalled();
+    expect(mockDirCreate).toHaveBeenCalled();
+  });
+
+  it('still proceeds if stale-file delete throws (best-effort cleanup)', async () => {
+    const FileSystem = require('expo-file-system');
+    FileSystem.File.mockImplementationOnce((...args: unknown[]) => {
+      const parts = args.map((a: unknown) =>
+        typeof a === 'object' && a !== null && 'uri' in a ? (a as { uri: string }).uri : String(a)
+      );
+      return {
+        uri: parts.join('/'),
+        exists: true,
+        create: mockFileCreate,
+        copy: mockFileCopy,
+        delete: jest.fn(() => {
+          throw new Error('EACCES');
+        }),
+      };
+    });
+
+    mockTakePictureAsync.mockResolvedValue({ uri: 'file://test.jpg' });
+    const { getByLabelText } = render(<ScanScreen />);
+    await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
+    // Cleanup failed, but create() is idempotent so it still runs. If it succeeds,
+    // the scan proceeds.
+    expect(mockDirCreate).toHaveBeenCalled();
+    expect(mockStartScan).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Failure-path matrix: every throw site must (a) block startScan,
+// (b) show the user an error banner, (c) tag Sentry with the stage.
+// This matrix is the guardrail against regressions of #174 and the silent-
+// failure class of bug.
+// ---------------------------------------------------------------------------
+describe('ScanScreen — capture failure paths surface banners', () => {
+  it('Directory.create() throws → banner shown, stage=dir_create, no scan', async () => {
+    mockDirCreate.mockImplementationOnce(() => {
+      throw new Error('EEXIST: file with same path exists');
+    });
+    mockTakePictureAsync.mockResolvedValue({ uri: 'file://test.jpg' });
+    const { getByLabelText } = render(<ScanScreen />);
+    await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
+
+    expect(mockStartScan).not.toHaveBeenCalled();
+    expect(mockShowBanner).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error' })
+    );
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        tags: expect.objectContaining({ stage: 'dir_create' }),
+      })
+    );
+  });
+
+  it('File.copy() throws (disk full) → banner shown, stage=file_copy, no scan', async () => {
+    mockFileCopy.mockImplementationOnce(() => {
+      throw new Error('ENOSPC: no space left on device');
+    });
+    mockTakePictureAsync.mockResolvedValue({ uri: 'file://test.jpg' });
+    const { getByLabelText } = render(<ScanScreen />);
+    await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
+
+    expect(mockStartScan).not.toHaveBeenCalled();
+    expect(mockShowBanner).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error' })
+    );
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        tags: expect.objectContaining({ stage: 'file_copy' }),
+      })
+    );
+  });
+
+  it('takePictureAsync rejects → banner shown, stage=take_picture, no scan', async () => {
+    mockTakePictureAsync.mockRejectedValueOnce(new Error('camera hardware error'));
+    const { getByLabelText } = render(<ScanScreen />);
+    await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
+
+    expect(mockStartScan).not.toHaveBeenCalled();
+    expect(mockShowBanner).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error' })
+    );
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        tags: expect.objectContaining({ stage: 'take_picture' }),
+      })
+    );
+  });
+
+  it('error banner includes a retry action that re-runs capture', async () => {
+    mockDirCreate.mockImplementationOnce(() => {
+      throw new Error('EEXIST');
+    });
+    mockTakePictureAsync.mockResolvedValue({ uri: 'file://test.jpg' });
+    const { getByLabelText } = render(<ScanScreen />);
+    await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
+
+    const bannerCall = mockShowBanner.mock.calls[0][0];
+    expect(bannerCall.actions).toBeDefined();
+    expect(bannerCall.actions.length).toBeGreaterThan(0);
+    // Invoking the retry action should trigger capture again.
+    await act(async () => bannerCall.actions[0].onPress());
+    expect(mockTakePictureAsync).toHaveBeenCalledTimes(2);
+  });
+
+  it('capture button is re-enabled after a failure (finally runs)', async () => {
+    mockDirCreate.mockImplementationOnce(() => {
+      throw new Error('EEXIST');
+    });
+    mockTakePictureAsync.mockResolvedValue({ uri: 'file://test.jpg' });
+    const { getByLabelText } = render(<ScanScreen />);
+    await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
+    // Second press must actually invoke takePictureAsync (not be blocked by
+    // capturing=true lingering after the throw).
+    await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
+    expect(mockTakePictureAsync).toHaveBeenCalledTimes(2);
+  });
+
+  it('happy path does NOT show an error banner', async () => {
+    mockTakePictureAsync.mockResolvedValue({ uri: 'file://test.jpg' });
+    const { getByLabelText } = render(<ScanScreen />);
+    await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
+    expect(mockShowBanner).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Double-tap filename collision guard
+// ---------------------------------------------------------------------------
+describe('ScanScreen — double-tap filename collisions', () => {
+  it('uses a sequence counter so two captures in the same ms get unique filenames', async () => {
+    // Freeze Date.now() so only the sequence counter differentiates the URIs.
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+    mockTakePictureAsync.mockResolvedValue({ uri: 'file://test.jpg' });
+
+    const { getByLabelText } = render(<ScanScreen />);
+    await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
+    await act(async () => fireEvent.press(getByLabelText('Capture book cover')));
+
+    const uris = mockStartScan.mock.calls.map((c) => c[1]);
+    expect(uris).toHaveLength(2);
+    expect(uris[0]).not.toEqual(uris[1]);
+    nowSpy.mockRestore();
   });
 });

--- a/frontend/app/(tabs)/scan.tsx
+++ b/frontend/app/(tabs)/scan.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { Sentry } from '../../lib/sentry';
 import { useTheme } from '../../hooks/useTheme';
 import { useScanJobs } from '../../hooks/useScanJobs';
+import { useBanner } from '../../hooks/useBanner';
 
 type InputMode = 'camera' | 'search';
 type CameraFacing = 'back' | 'front';
@@ -15,12 +16,14 @@ export default function ScanScreen() {
   const { theme } = useTheme();
   const { t } = useTranslation('scan');
   const { startScan } = useScanJobs();
+  const { showBanner } = useBanner();
   const [permission, requestPermission] = useCameraPermissions();
   const [inputMode, setInputMode] = useState<InputMode>('camera');
   const [query, setQuery] = useState('');
   const [facing, setFacing] = useState<CameraFacing>('back');
   const [capturing, setCapturing] = useState(false);
   const cameraRef = useRef<CameraView>(null);
+  const captureSeq = useRef(0);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const webInputRef = useRef<any>(null);
 
@@ -50,6 +53,9 @@ export default function ScanScreen() {
       message: 'Camera capture started',
       level: 'info',
     });
+    // Track which pipeline stage is executing so the catch block can tag the
+    // failure precisely. Each silent failure previously looked identical in Sentry.
+    let stage: 'take_picture' | 'dir_create' | 'file_copy' | 'start_scan' = 'take_picture';
     try {
       const photo = await cameraRef.current.takePictureAsync({
         quality: 0.7,
@@ -64,15 +70,40 @@ export default function ScanScreen() {
         return;
       }
 
-      // Copy temp file to persistent document directory.
-      const destDir = new Directory(Paths.document, 'scan-queue');
-      if (!destDir.exists) {
-        destDir.create();
+      // Heal corruption from the pre-#174 bug: if an earlier version of the app
+      // wrote a File (not a Directory) at the scan-queue path, delete it so the
+      // Directory.create() call below doesn't collide with it.
+      stage = 'dir_create';
+      try {
+        const stalePath = new File(Paths.document, 'scan-queue');
+        if (stalePath.exists) {
+          stalePath.delete();
+          Sentry.addBreadcrumb({
+            category: 'scan',
+            message: 'Removed stale scan-queue file from pre-#174 state',
+            level: 'info',
+          });
+        }
+      } catch {
+        // Best-effort cleanup — if this throws we'll still attempt create() below
+        // and surface that failure to the user.
       }
-      const destFile = new File(destDir, `${Date.now()}.jpg`);
+
+      // Copy temp file to persistent document directory. idempotent: true means
+      // create() is a no-op when the directory already exists (expo-file-system
+      // otherwise throws). intermediates: true guards first-launch edge cases.
+      const destDir = new Directory(Paths.document, 'scan-queue');
+      destDir.create({ intermediates: true, idempotent: true });
+
+      stage = 'file_copy';
+      // Sequence counter prevents filename collisions if two captures land in
+      // the same millisecond (double-tap race).
+      const seq = captureSeq.current++;
+      const destFile = new File(destDir, `${Date.now()}-${seq}.jpg`);
       const sourceFile = new File(photo.uri);
       sourceFile.copy(destFile);
 
+      stage = 'start_scan';
       Sentry.addBreadcrumb({
         category: 'scan',
         message: 'Photo saved, starting scan',
@@ -82,8 +113,16 @@ export default function ScanScreen() {
       startScan('image', destFile.uri);
     } catch (error) {
       Sentry.captureException(error, {
-        tags: { feature: 'camera-capture' },
+        tags: { feature: 'camera-capture', stage },
         extra: { facing },
+      });
+      // Give the user visible feedback instead of just logging to Sentry. The
+      // original bug shipped precisely because this catch was silent.
+      showBanner({
+        message: t('scanFailedMessage'),
+        type: 'error',
+        actions: [{ label: t('retryNow'), onPress: () => handleCapture() }],
+        duration: 8000,
       });
     } finally {
       setCapturing(false);


### PR DESCRIPTION
## Summary

Fixes #174. Camera capture played the shutter sound but nothing happened afterward — no scan job, no error shown.

**Root cause:** the first fix pass (commit `0599d2a`) switched from `File` → `Directory` for the `scan-queue` path, but every device that ran the old buggy version still had an empty *file* sitting at that path. `expo-file-system`'s `Directory.create()` throws "a file with the same path already exists" unless called with `idempotent: true`. The surrounding `try/catch` only logged to Sentry, so the user saw nothing.

## Changes

**`frontend/app/(tabs)/scan.tsx`**
- Self-heal: detect and delete any stale `File` at `scan-queue` before creating the directory
- Call `destDir.create({ intermediates: true, idempotent: true })` — safe on every capture
- Track pipeline stage (`take_picture | dir_create | file_copy | start_scan`) and tag Sentry with it
- Show an error banner with a **Retry** action on every failure path (via `BannerContext`) — capture is no longer silent
- Add a monotonic sequence counter to the destination filename to prevent same-millisecond collisions

## Test strategy — catches this class of bug on every code change

**`frontend/__tests__/unit/ScanScreen.test.tsx`** (31 → 40 tests)
- Failure-path matrix: `Directory.create` throws, `File.copy` throws, `takePictureAsync` rejects — each asserts no scan, error banner shown, Sentry tagged with the correct `stage`
- Stale-file healing: delete+create sequence verified
- **Regression guard**: asserts `create()` is called with `{ intermediates: true, idempotent: true }` — removing `idempotent` will fail tests immediately
- Double-tap collision guard: two captures in the same ms get unique URIs
- Retry action actually re-invokes capture

**`frontend/__tests__/integration/ScanCaptureFlow.test.tsx`** (new, 4 tests)
Uses the **real** `BannerProvider` + `InAppBanner` — asserts the error text actually renders on screen when capture fails. Would have caught both #174 and this follow-up silent-failure bug.

Full suite: **215 tests passing across 28 suites.**

## Test plan

- [x] `npx jest __tests__/unit/ScanScreen.test.tsx` — 40 pass
- [x] `npx jest __tests__/integration/ScanCaptureFlow.test.tsx` — 4 pass
- [x] `npx jest` (full suite) — 215 pass
- [ ] Manual: run dev build on a device that has the stale `scan-queue` file, confirm capture succeeds
- [ ] Manual: force `Directory.create` to throw, confirm error banner appears on screen with Retry
- [ ] Manual: rapid-tap capture 5× — verify no filename collisions in Sentry breadcrumbs

https://claude.ai/code/session_01TxDgK6yh3VevYkpZzsRK76