### PR TITLE
docs(android): add first-time local setup — debug keystore generation

### DIFF
--- a/docs/claude/android-ci.md
+++ b/docs/claude/android-ci.md
@@ -31,6 +31,30 @@ brew install --cask zulu@17
 Or use a version manager with the committed `.tool-versions` file at the
 repo root (`java zulu-17.64.17`): `asdf install` / `mise install`.
 
+## First-time local Android setup
+
+After cloning, before your first `npx expo run:android`, you need two things:
+
+**1. JDK 17 on `JAVA_HOME`** (see the section above).
+
+**2. A local debug keystore.** `frontend/android/app/debug.keystore` is
+gitignored (CI generates a throwaway one at build time). Generate one locally
+with the standard Android debug credentials so AGP's default signing config
+picks it up:
+
+```bash
+keytool -genkey -v \
+  -keystore frontend/android/app/debug.keystore \
+  -alias androiddebugkey \
+  -keyalg RSA -keysize 2048 -validity 10000 \
+  -storepass android -keypass android \
+  -dname "CN=Android Debug,O=Android,C=US"
+```
+
+You only need to do this once per clone. If you ever see
+`Keystore file '.../debug.keystore' not found for signing config 'debug'`
+at `:app:validateSigningDebug`, re-run the command above.
+
 ## Why `npm ci` must run before Gradle
 
 `node_modules/` is gitignored. Gradle's `settings.gradle` calls


### PR DESCRIPTION
## Summary
After #180 documented the JDK 17 requirement, the next blocker for a new dev running \`npx expo run:android\` for the first time is the gitignored \`debug.keystore\` — the build fails ~5 min in at \`:app:validateSigningDebug\` with no pointer to the keytool incantation.

Add a \"First-time local Android setup\" section to \`docs/claude/android-ci.md\` immediately after the JDK 17 requirement, with the standard \`keytool -genkey\` command using Android's default debug credentials (\`android\`/\`android\`) so AGP's default \`signingConfigs.debug\` picks it up.

Closes #181.

## Test plan
- [x] Docs-only change — no code affected
- [x] Verified the keytool command works (used it locally to unblock my own #180 verification)
- [ ] Confirm the two first-run prerequisites now sit adjacent and read cleanly for a new dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)