### PR TITLE
docs: rewrite README.md as the monorepo doc hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,74 @@
-# Bookshelf
+# Bookshelf (BookShelfAI)
 
-A personal mobile + web app to scan books, track your wishlist, and manage your reading collection.
+Personal mobile + web app for scanning book covers with your camera, identifying them via AI vision, and tracking your reading collection through **wishlisted → purchased → reading → read**.
 
-**Stack:** Expo (React Native) · FastAPI · PostgreSQL · Render · GitHub Actions
+Point your camera at a book, the app identifies it (OpenAI `gpt-4o-mini` vision + Google Books enrichment), you pick the right candidate, and it lands in your wishlist. One codebase ships to iOS, Android, and web.
 
-## Repo Structure
+## Stack
+
+**Frontend** — Expo SDK 55 · React Native 0.83 · Expo Router · TypeScript · i18next (10 locales) · Sentry
+**Backend** — FastAPI · SQLAlchemy (async) · Alembic · PostgreSQL · slowapi rate limiting · JWT (RS256) auth via Google OAuth
+**External** — OpenAI Vision · Google Books API · Open Library · Cloudflare (Turnstile + WAF) · Sentry
+**Infra** — Render (backend + Postgres) · Xcode Cloud (iOS) · local Gradle → Play Console (Android) · GitHub Actions CI
+
+## Repo map
 
 ```
-bookshelf/
-├── backend/    → FastAPI API, SQLAlchemy models, Alembic migrations
-├── frontend/   → Expo (React Native + Web) app
-├── docs/       → Architecture, API, and security documentation
-└── .github/    → CI/CD workflows
+book_app/
+├── backend/         FastAPI app, SQLAlchemy models, Alembic migrations, pytest suite
+├── frontend/        Expo (iOS + Android + web) app, Jest tests, native Xcode + Gradle projects
+├── docs/            All project documentation (this README is the hub)
+│   └── claude/      Claude-specific instructions for working inside this repo
+├── .github/         CI workflows, PR template, rulesets
+├── CLAUDE.md        Load-bearing rules for Claude Code sessions (read before contributing)
+├── render.yaml      Render service + DB definition (backend auto-deploys from dev)
+└── .tool-versions   asdf/mise version pins (JDK 17 for Android)
 ```
 
-## Getting Started
+## Quickstart
 
-### Backend
+Full end-to-end setup is in [`docs/getting-started.md`](docs/getting-started.md). Short version:
 
 ```bash
-cd backend
-python -m venv .venv
-source .venv/bin/activate   # Windows: .venv\Scripts\activate
+# 1. Backend
+cd backend && python -m venv .venv && source .venv/bin/activate
 pip install -r requirements-dev.txt
-cp .env.example .env        # fill in your values
+cp .env.example .env      # fill in Google OAuth, Google Books, OpenAI, Sentry keys
 alembic upgrade head
 uvicorn app.main:app --reload
+
+# 2. Frontend (new terminal)
+cd frontend && npm install
+npx expo start            # press i for iOS sim, a for Android, w for web
 ```
 
-### Frontend
+**Prerequisites:** PostgreSQL 15+, Python 3.12+, Node 20.x, JDK 17 (`export JAVA_HOME=$(/usr/libexec/java_home -v 17)`) for Android, Xcode for iOS.
 
-```bash
-cd frontend
-npm install
-npx expo start
-```
+## Workflow rules (summary)
 
-## Development Workflow
-
-- `feature/*` → `develop` → `main`
-- All PRs must pass CI (lint, format, tests, 80% coverage)
-- `develop` auto-deploys to Render staging
-- `main` auto-deploys to Render production
-
-## Environment Variables
-
-See `backend/.env.example` for all required variables.
+- Branch from `dev` → `feature/<name>` or `bug/<name>` → open PR targeting `dev` → CI green → merge
+- **Never** push directly to `dev` or `main`
+- `dev` auto-deploys the backend to Render production (per `render.yaml`)
+- Full rule list: [`CLAUDE.md`](CLAUDE.md)
 
 ## Documentation
 
-- [Architecture](docs/architecture.md)
-- [API Reference](docs/api.md)
-- [Security](docs/security.md)
+| Doc | Purpose | Status |
+|---|---|---|
+| [`docs/getting-started.md`](docs/getting-started.md) | End-to-end local dev setup (DB + backend + frontend + first scan) | ⏳ [#187](../../issues/187) |
+| [`docs/architecture.md`](docs/architecture.md) | System design, middleware stack, auth architecture, decision records | ⏳ [#186](../../issues/186) |
+| [`docs/project-structure.md`](docs/project-structure.md) | Monorepo layout, conventions, "how to add a ..." recipes | ⏳ [#191](../../issues/191) |
+| [`docs/features.md`](docs/features.md) | User-facing features, scan flow + auth flow sequence diagrams | ⏳ [#188](../../issues/188) |
+| [`docs/data-model.md`](docs/data-model.md) | ER diagram, entity reference, book-dedup strategy | ⏳ [#189](../../issues/189) |
+| [`docs/api.md`](docs/api.md) | REST endpoint reference with examples and error codes | ⏳ [#190](../../issues/190) |
+| [`docs/integrations.md`](docs/integrations.md) | Google OAuth / Books / OpenAI / Open Library / Sentry / Cloudflare / Render | ⏳ [#192](../../issues/192) |
+| [`docs/deployment.md`](docs/deployment.md) | Render config, env vars, release process, rollback | ⏳ [#193](../../issues/193) |
+| [`docs/testing.md`](docs/testing.md) | Test strategy (unit/integration/security/accuracy/perf), patterns, how to run | ⏳ [#194](../../issues/194) |
+| [`docs/security.md`](docs/security.md) | Security controls, OWASP test cases, incident runbook | ✅ |
+| [`docs/claude/`](docs/claude/) | Claude-specific guides (git workflow, iOS/Android CI, backend/frontend conventions) | ✅ |
+
+> **Doc overhaul in progress.** Items marked ⏳ are being written incrementally — see [#185–#196](../../issues?q=is%3Aissue+label%3Adocumentation) (12 PRs, one per doc). This note comes out once all are merged.
+
+## For Claude sessions
+
+Start by reading [`CLAUDE.md`](CLAUDE.md). It covers branching rules, testing requirements, native build constraints (iOS and Android), and the hard rules this repo enforces (no raw SQL, no hardcoded colors, no `AsyncStorage` for tokens, every endpoint rate-limited, i18n on every user-facing string, etc.).


### PR DESCRIPTION
Part 1 of 12 in the documentation overhaul (see [plan](../../issues?q=is%3Aissue+label%3Adocumentation)).

## Summary
Rewrites `README.md` from a 55-line stub into the monorepo doc hub. Fixes two truthful inaccuracies:
- Old README said \`develop → main\` with main auto-deploying to prod; `render.yaml` actually deploys from `dev`.
- Old doc index only listed 3 files; the real doc tree is 11 files (growing to 12 with this overhaul).

## What's new
- Concrete product description (not just stack names)
- Repo map with one-liner per top-level entry
- Doc index table with live status markers (✅ exists, ⏳ with linked issue for in-progress docs)
- Progress note pointing to #185–#196 (the 12 doc-overhaul PRs)
- Pointer to CLAUDE.md

## Test plan
- [x] Internal links grepped + verified (3 resolve to existing files today: CLAUDE.md, docs/security.md, docs/claude/; others will resolve as their PRs merge)
- [x] Diff is docs-only (README.md only)
- [ ] GitHub renders the status table with emoji + issue links correctly

Closes #185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)