### PR TITLE
docs(security): cross-refs to new doc tree + missing middleware rows

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -2,17 +2,22 @@
 
 See [~/.claude/standards/security.md](~/.claude/standards/security.md) for universal security standards.
 
+**Related docs:** [`architecture.md`](architecture.md#middleware-stack) (middleware stack + rate limiting) · [`integrations.md`](integrations.md#cloudflare) (Turnstile + WAF) · [`api.md`](api.md#conventions) (error response format) · [`data-model.md`](data-model.md#refresh_tokens-backendappmodelsrefresh_tokenpy) (JTI revocation table)
+
 ## Security Controls
 
 | Concern | Solution |
 |---------|----------|
 | JWT algorithm confusion | Pinned to RS256; all other algorithms including `none` rejected |
 | JWT expiry | 24hr access token, 7-day refresh token with JTI revocation |
+| Refresh token theft | Single-use rotation — every `/auth/refresh` revokes the old `jti` and issues a new one |
 | Single-user lock | `ALLOWED_EMAILS` env var checked post-Google-auth |
-| Rate limiting | `slowapi` — per-user (auth'd) / per-IP (unauth'd); 10 req/min on `/scan` |
+| Rate limiting | `slowapi` — per-client-IP; 10 req/min on `/scan`, 5/min auth, 120/min reads, etc. |
 | Real client IP | `CloudflareRealIPMiddleware` reads `CF-Connecting-IP` in production |
+| Host header spoofing | `TrustedHostMiddleware` (prod only) rejects requests with Host header outside `TRUSTED_HOSTS`; `/health` exempted via `_HealthExemptTrustedHost` so origin-direct probes still work |
+| Request size limit | `RequestSizeLimitMiddleware` drops bodies > 10 MB with 413 before reading the stream |
 | DDoS / Bot protection | Cloudflare free tier (Bot Fight Mode, HTTP DDoS protection) |
-| Bot protection on /scan | Cloudflare Turnstile — opt-in via `TURNSTILE_SECRET_KEY` env var |
+| Bot protection on /scan | Cloudflare Turnstile — opt-in via `TURNSTILE_SECRET_KEY` env var. Request must carry `cf-turnstile-response`; verified against Cloudflare siteverify with 5s timeout |
 | CORS | Explicit method/header allowlist; wildcard origins rejected at config validation |
 | Input validation | Pydantic on all endpoints; extension + MIME + size + magic bytes on uploads |
 | SQL injection | SQLAlchemy ORM throughout; no raw SQL |


### PR DESCRIPTION
Part 11 of 12 in the documentation overhaul. Smallest PR of the batch (+7 / -2 lines).

## Summary
Minor touch-ups to the existing 220-line `docs/security.md` to cross-link with the new doc tree and capture three middleware/auth controls that weren't in the table.

## What's in it
- **Related docs** line at the top of the file pointing to specific anchors in architecture.md, integrations.md, api.md, data-model.md
- **3 new rows** in the Security Controls table:
  - Refresh token theft (single-use rotation via JTI revocation — shipped in the auth endpoints but not previously listed here)
  - Host header spoofing (TrustedHostMiddleware in prod + the /health exemption via _HealthExemptTrustedHost shipped in #184)
  - Request size limit (RequestSizeLimitMiddleware, 10 MB → 413)
- **Expanded** Turnstile row with request format + 5s siteverify timeout detail
- **Clarified** rate-limiting row: per-IP keying + actual per-endpoint limits (10/scan, 5/auth, 120/reads) instead of just "10/min"

## Test plan
- [x] Diff is 7 insertions, 2 deletions — exactly the touch-up PR promised in the overhaul plan
- [x] Every new anchor link verified against the target doc's heading
- [ ] GitHub renders the table correctly

Closes #195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)