### PR TITLE
ci: add doc-reminder workflow + PR-template checklist item

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,9 @@
 ## Test plan
 <!-- How was this tested? -->
 
+## Docs checklist
+- [ ] Docs updated (or confirmed N/A) — see `docs/` tree
+
 ## iOS Checklist (complete if touching `frontend/ios/` or `ci_scripts/`)
 - [ ] Ran `pod install` locally and committed `Podfile.lock` changes
 - [ ] `js-bundle-check` CI job passes

--- a/.github/workflows/doc-reminder.yml
+++ b/.github/workflows/doc-reminder.yml
@@ -1,0 +1,126 @@
+name: Doc-update reminder
+
+# Informational PR comment that flags which docs in docs/ might need
+# updating based on which code paths were changed. Never fails the check.
+# Comment is updated in place on subsequent pushes (not spammed).
+#
+# See the documentation-overhaul plan + wcmchenry3-stack/book_app#196
+# for the full path → doc mapping rationale.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  doc-reminder:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Flag docs and upsert reminder comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+
+            // Path pattern → doc flags.
+            const mapping = [
+              { pattern: /^backend\/app\/api\//,             docs: ['docs/api.md', 'docs/features.md'] },
+              { pattern: /^backend\/app\/models\//,          docs: ['docs/data-model.md'] },
+              { pattern: /^backend\/app\/services\//,        docs: ['docs/integrations.md', 'docs/architecture.md'] },
+              { pattern: /^backend\/app\/core\/config\.py$/, docs: ['docs/getting-started.md', 'docs/deployment.md'] },
+              { pattern: /^backend\/app\/main\.py$/,         docs: ['docs/architecture.md'] },
+              { pattern: /^frontend\/app\/\(tabs\)\//,       docs: ['docs/features.md'] },
+              { pattern: /^frontend\/app\/\(auth\)\//,       docs: ['docs/features.md'] },
+              { pattern: /^frontend\/contexts\//,            docs: ['docs/features.md', 'docs/architecture.md'] },
+              { pattern: /^frontend\/src\/i18n\//,           docs: ['docs/features.md'] },
+              { pattern: /^\.github\/workflows\//,           docs: ['docs/deployment.md', 'docs/testing.md'] },
+              { pattern: /^render\.yaml$/,                   docs: ['docs/deployment.md'] },
+              { pattern: /^Procfile$/,                       docs: ['docs/deployment.md'] },
+            ];
+
+            const changedFiles = await github.paginate(
+              github.rest.pulls.listFiles,
+              { owner, repo, pull_number: pr.number, per_page: 100 }
+            );
+            const changed = changedFiles.map(f => f.filename);
+
+            const flaggedDocs = new Set();
+            const triggers = [];
+            for (const m of mapping) {
+              const hits = changed.filter(p => m.pattern.test(p));
+              if (hits.length) {
+                for (const d of m.docs) flaggedDocs.add(d);
+                triggers.push({ pattern: String(m.pattern), hits, docs: m.docs });
+              }
+            }
+
+            const marker = '<!-- doc-reminder:v1 -->';
+
+            // Nothing flagged → delete any stale comment we previously posted, then exit.
+            if (flaggedDocs.size === 0) {
+              const comments = await github.paginate(
+                github.rest.issues.listComments,
+                { owner, repo, issue_number: pr.number, per_page: 100 }
+              );
+              const stale = comments.find(c => c.body && c.body.includes(marker));
+              if (stale) {
+                await github.rest.issues.deleteComment({ owner, repo, comment_id: stale.id });
+              }
+              core.info('No flagged docs for this change set.');
+              return;
+            }
+
+            // Build the comment body.
+            const docsTouched = changed.filter(p => flaggedDocs.has(p));
+            const allCovered = [...flaggedDocs].every(d => docsTouched.includes(d));
+
+            const lines = [marker, '## 📚 Doc-update reminder', ''];
+            if (allCovered) {
+              lines.push('✅ This PR already touches every flagged doc for the change set — looks good.');
+              lines.push('');
+            } else {
+              lines.push('Changes in this PR touch code paths that typically call for doc updates.');
+              lines.push('Consider whether each doc below needs edits; this check is informational and never fails CI.');
+              lines.push('');
+              lines.push('### Flagged docs');
+              lines.push('');
+              for (const d of [...flaggedDocs].sort()) {
+                const status = docsTouched.includes(d) ? '✅' : '⏳';
+                lines.push('- ' + status + ' `' + d + '`');
+              }
+              lines.push('');
+            }
+            lines.push('### Why these were flagged');
+            lines.push('');
+            for (const t of triggers) {
+              const firstThree = t.hits.slice(0, 3).map(h => '`' + h + '`').join(', ');
+              const extra = t.hits.length > 3 ? ' _(+' + (t.hits.length - 3) + ' more)_' : '';
+              const docList = t.docs.map(d => '`' + d + '`').join(', ');
+              lines.push('- `' + t.pattern + '` matched: ' + firstThree + extra + ' → flags ' + docList);
+            }
+            lines.push('');
+            lines.push('<sub>Full mapping lives in `.github/workflows/doc-reminder.yml`. PRs that consciously ship without doc updates can tick the "N/A" box in the PR template.</sub>');
+            const body = lines.join('\n');
+
+            // Upsert: find existing marker comment or create new.
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number: pr.number, per_page: 100 }
+            );
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+
+            if (existing) {
+              if (existing.body === body) {
+                core.info('Comment already up to date.');
+              } else {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+                core.info('Updated existing reminder comment.');
+              }
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: pr.number, body });
+              core.info('Created new reminder comment.');
+            }


### PR DESCRIPTION
Part 12 of 12 — the final piece of the documentation overhaul. Automates the "did I update relevant docs?" question on every future PR.

## Summary
Two non-blocking additions that make doc-hygiene visible by default without slowing anyone down.

## 1. `.github/workflows/doc-reminder.yml`
Runs on every `pull_request` event. Inspects the diff and posts a **single** comment listing which docs in `docs/` are likely affected by this change set.

**Path → doc mapping:**

| Changed path | Flags |
|---|---|
| `backend/app/api/**` | `api.md` + `features.md` |
| `backend/app/models/**` | `data-model.md` |
| `backend/app/services/**` | `integrations.md` + `architecture.md` |
| `backend/app/core/config.py` | `getting-started.md` + `deployment.md` |
| `backend/app/main.py` | `architecture.md` |
| `frontend/app/(tabs)/**` + `(auth)/**` | `features.md` |
| `frontend/contexts/**` | `features.md` + `architecture.md` |
| `frontend/src/i18n/**` | `features.md` |
| `.github/workflows/**` | `deployment.md` + `testing.md` |
| `render.yaml`, `Procfile` | `deployment.md` |

**Comment shape:** lists flagged docs with ✅ (already touched) or ⏳ (still needs attention), then shows **why** (which pattern matched which files). Idempotent — upserts via `<!-- doc-reminder:v1 -->` marker. Deletes the stale comment if a later push removes all triggers.

**Non-blocking** — purely informational, never fails CI. Permissions scoped to `contents: read` + `pull-requests: write` only.

**Single-step implementation** — everything runs inside one `github-script` step so multi-line comment bodies don't have to cross GH Actions output boundaries (which mangles backticks and template literals).

## 2. `.github/PULL_REQUEST_TEMPLATE.md`
Adds one checkbox between "Test plan" and the existing iOS checklist:

```markdown
## Docs checklist
- [ ] Docs updated (or confirmed N/A) — see `docs/` tree
```

Passive backstop for PRs where the Action didn't fire (e.g. draft-only changes).

## Test plan
- [x] YAML valid (workflow parses)
- [x] `github-script` usage: paginates listFiles + listComments; uses script @v7 with proper context
- [x] Marker-based upsert prevents comment spam on rebase/force-push
- [ ] This PR is itself the first live test — expect the reminder to fire flagging `docs/deployment.md` + `docs/testing.md` (since this PR touches `.github/workflows/`)

Closes #196. Completes the 12-PR documentation overhaul (#185–#196).

🤖 Generated with [Claude Code](https://claude.com/claude-code)