### PR TITLE
docs: finalize README doc index — drop overhaul-in-progress markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,21 +53,19 @@ npx expo start            # press i for iOS sim, a for Android, w for web
 
 ## Documentation
 
-| Doc | Purpose | Status |
-|---|---|---|
-| [`docs/getting-started.md`](docs/getting-started.md) | End-to-end local dev setup (DB + backend + frontend + first scan) | ⏳ [#187](../../issues/187) |
-| [`docs/architecture.md`](docs/architecture.md) | System design, middleware stack, auth architecture, decision records | ⏳ [#186](../../issues/186) |
-| [`docs/project-structure.md`](docs/project-structure.md) | Monorepo layout, conventions, "how to add a ..." recipes | ⏳ [#191](../../issues/191) |
-| [`docs/features.md`](docs/features.md) | User-facing features, scan flow + auth flow sequence diagrams | ⏳ [#188](../../issues/188) |
-| [`docs/data-model.md`](docs/data-model.md) | ER diagram, entity reference, book-dedup strategy | ⏳ [#189](../../issues/189) |
-| [`docs/api.md`](docs/api.md) | REST endpoint reference with examples and error codes | ⏳ [#190](../../issues/190) |
-| [`docs/integrations.md`](docs/integrations.md) | Google OAuth / Books / OpenAI / Open Library / Sentry / Cloudflare / Render | ⏳ [#192](../../issues/192) |
-| [`docs/deployment.md`](docs/deployment.md) | Render config, env vars, release process, rollback | ⏳ [#193](../../issues/193) |
-| [`docs/testing.md`](docs/testing.md) | Test strategy (unit/integration/security/accuracy/perf), patterns, how to run | ⏳ [#194](../../issues/194) |
-| [`docs/security.md`](docs/security.md) | Security controls, OWASP test cases, incident runbook | ✅ |
-| [`docs/claude/`](docs/claude/) | Claude-specific guides (git workflow, iOS/Android CI, backend/frontend conventions) | ✅ |
-
-> **Doc overhaul in progress.** Items marked ⏳ are being written incrementally — see [#185–#196](../../issues?q=is%3Aissue+label%3Adocumentation) (12 PRs, one per doc). This note comes out once all are merged.
+| Doc | Purpose |
+|---|---|
+| [`docs/getting-started.md`](docs/getting-started.md) | End-to-end local dev setup (DB + backend + frontend + first scan) |
+| [`docs/architecture.md`](docs/architecture.md) | System design, middleware stack, auth architecture, decision records |
+| [`docs/project-structure.md`](docs/project-structure.md) | Monorepo layout, conventions, "how to add a ..." recipes |
+| [`docs/features.md`](docs/features.md) | User-facing features, scan flow + auth flow sequence diagrams |
+| [`docs/data-model.md`](docs/data-model.md) | ER diagram, entity reference, book-dedup strategy |
+| [`docs/api.md`](docs/api.md) | REST endpoint reference with examples and error codes |
+| [`docs/integrations.md`](docs/integrations.md) | Google OAuth / Books / OpenAI / Open Library / Sentry / Cloudflare / Render |
+| [`docs/deployment.md`](docs/deployment.md) | Render config, env vars, release process, rollback |
+| [`docs/testing.md`](docs/testing.md) | Test strategy (unit/integration/security/accuracy/perf), patterns, how to run |
+| [`docs/security.md`](docs/security.md) | Security controls, OWASP test cases, incident runbook |
+| [`docs/claude/`](docs/claude/) | Claude-specific guides (git workflow, iOS/Android CI, backend/frontend conventions) |
 
 ## For Claude sessions
 


### PR DESCRIPTION
## Summary
All 11 user-facing docs in the index are merged to dev (#185 README, #186 architecture, #187 getting-started, #188 features, #189 data-model, #190 api, #191 project-structure, #192 integrations, #193 deployment, #194 testing, #195 security touch-ups). Drop the ⏳ progress markers, the Status column, and the overhaul-in-progress banner note.

Every link in the doc index now resolves to an actual file (verified with grep).

## Diff
-15 / +13 — Status column collapsed, 10 issue-link shortcuts removed, banner note removed.

## Test plan
- [x] `grep -oE '\]\([^)]+\)' README.md` shows only resolvable file links + CLAUDE.md
- [ ] Markdown renders as a clean 2-column table

🤖 Generated with [Claude Code](https://claude.com/claude-code)