### PR TITLE
security: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug report
+about: Report a bug
+labels: bug
+---
+
+## Description
+<!-- Clear, concise description of the bug -->
+
+## Steps to reproduce
+1.
+2.
+3.
+
+## Expected behaviour
+
+## Actual behaviour
+
+## Environment
+- OS:
+- Browser / runtime:
+- Version / branch:
+
+## Logs / screenshots
+<!-- Paste relevant logs or attach screenshots -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement
+labels: enhancement
+---
+
+## Problem statement
+<!-- What problem does this solve? Who is affected? -->
+
+## Proposed solution
+<!-- How would you solve it? -->
+
+## Alternatives considered
+<!-- What other approaches did you consider and why did you reject them? -->
+
+## Acceptance criteria
+- [ ]
+- [ ]


### PR DESCRIPTION
## Summary
Adds the standard org issue templates. `SECURITY.md` and `PULL_REQUEST_TEMPLATE.md` already exist with repo-specific content — this only adds what's missing.

## Files added
- `.github/ISSUE_TEMPLATE/bug_report.md`
- `.github/ISSUE_TEMPLATE/feature_request.md`

## Why now
App Store / Google Play submission — having structured reporting in place before submission is expected.

## Test plan
- [ ] Confirm "Bug report" and "Feature request" templates appear when opening a new issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)