### PR TITLE
security: OWASP hardening — input limits, SSRF, file sanitization, token cleanup

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,6 +8,7 @@ on:
     branches: [dev]
     paths:
       - 'backend/app/**'
+      - 'backend/tests/security/**'
       - 'backend/requirements*.txt'
       - '.github/workflows/security.yml'
       - '.zap/**'
@@ -128,6 +129,8 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements-dev.txt
       - name: Run security test suite
+        env:
+          TURNSTILE_REQUIRED: "false"
         run: pytest -m security -v --tb=short
 
   # ── DAST: OWASP ZAP active scan ───────────────────────────────────────────
@@ -148,10 +151,10 @@ jobs:
           rules_file_name: '.zap/rules.tsv'
           cmd_options: '-z "-config scanner.attackStrength=LOW"'
           allow_issue_writing: false
-          # Report findings but don't fail — active scans against production
-          # may surface acceptable known issues. Review the artifact and
-          # promote to fail_action: true once a clean baseline is established.
-          fail_action: false
+          # rules.tsv classifies SQLi, XSS, RCE, and path traversal as FAIL.
+          # WARN/IGNORE rules suppress known false positives for a JSON API.
+          # Promoted from false after security hardening pass (PR #234).
+          fail_action: true
           artifact_name: zap-full-scan-report
       - uses: actions/upload-artifact@v7
         if: always()

--- a/backend/app/api/books.py
+++ b/backend/app/api/books.py
@@ -44,7 +44,7 @@ def _volume_to_candidate(volume: dict) -> BookCandidate:
 async def search_books(
     request: Request,
     q: str = Query(
-        ..., min_length=2, description="Free-text query, e.g. 'John Adams McCullough'"
+        ..., min_length=2, max_length=256, description="Free-text query, e.g. 'John Adams McCullough'"
     ),
     current_user: User = Depends(get_current_user),
 ) -> list[EnrichedBook]:

--- a/backend/app/api/books.py
+++ b/backend/app/api/books.py
@@ -44,7 +44,10 @@ def _volume_to_candidate(volume: dict) -> BookCandidate:
 async def search_books(
     request: Request,
     q: str = Query(
-        ..., min_length=2, max_length=256, description="Free-text query, e.g. 'John Adams McCullough'"
+        ...,
+        min_length=2,
+        max_length=256,
+        description="Free-text query, e.g. 'John Adams McCullough'",
     ),
     current_user: User = Depends(get_current_user),
 ) -> list[EnrichedBook]:

--- a/backend/app/api/scan.py
+++ b/backend/app/api/scan.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.auth.dependencies import get_current_user
 from app.core.config import settings
 from app.core.database import get_db
+from app.core.file_security import sanitize_image, scan_for_malware
 from app.core.file_validation import validate_magic_bytes
 from app.core.limiter import limiter
 from app.models.user import User
@@ -99,6 +100,14 @@ async def scan(
             status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
             detail="File content does not match declared type",
         )
+
+    # Antivirus scan (optional, controlled by CLAMAV_ENABLED setting).
+    # Runs on the original bytes before any re-encoding.
+    scan_for_malware(image_bytes)
+
+    # Strip all metadata (EXIF/XMP/IPTC) and neutralise polyglot payloads by
+    # re-encoding to JPEG.  Consistent with the data:image/jpeg type sent to OpenAI.
+    image_bytes = sanitize_image(image_bytes)
 
     identifier = ChatGPTVisionIdentifier()
     try:

--- a/backend/app/api/scan.py
+++ b/backend/app/api/scan.py
@@ -54,8 +54,10 @@ async def scan(
     db: AsyncSession = Depends(get_db),
     cf_turnstile_response: str | None = Form(None, alias="cf-turnstile-response"),
 ) -> list[EnrichedBook]:
-    # --- Cloudflare Turnstile bot check (when TURNSTILE_SECRET_KEY is configured) ---
-    if settings.turnstile_secret_key:
+    # --- Cloudflare Turnstile bot check ---
+    # Enabled when TURNSTILE_REQUIRED=true (the default).
+    # The startup handler already confirmed the secret key is present when required.
+    if settings.turnstile_required:
         if not cf_turnstile_response:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -30,6 +30,13 @@ class Settings(BaseSettings):
     # Leave empty in development to skip the check.
     turnstile_secret_key: str = ""
 
+    # ClamAV antivirus — optional malware scan on uploaded images.
+    # Requires a running ClamAV daemon (clamd) and pyclamd installed.
+    # Set CLAMAV_ENABLED=true when the Render instance has sufficient RAM (~300 MB).
+    clamav_enabled: bool = False
+    clamav_host: str = "localhost"
+    clamav_port: int = 3310
+
     # Testing (dev/staging only — never set in production)
     test_auth_secret: str = ""
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -25,10 +25,13 @@ class Settings(BaseSettings):
     google_books_api_key: str = ""
     open_library_base_url: str = "https://openlibrary.org"
 
-    # Cloudflare Turnstile — bot protection on /scan
-    # When set, every /scan request must include a valid cf-turnstile-response form field.
-    # Leave empty in development to skip the check.
+    # Cloudflare Turnstile — bot protection on /scan.
+    # turnstile_required=true (default) means every /scan request must supply a valid
+    # cf-turnstile-response token.  If turnstile_secret_key is absent at startup the
+    # app refuses to start, preventing a misconfigured production deploy.
+    # Set TURNSTILE_REQUIRED=false to explicitly opt out (dev / test environments).
     turnstile_secret_key: str = ""
+    turnstile_required: bool = True
 
     # ClamAV antivirus — optional malware scan on uploaded images.
     # Requires a running ClamAV daemon (clamd) and pyclamd installed.

--- a/backend/app/core/file_security.py
+++ b/backend/app/core/file_security.py
@@ -1,0 +1,130 @@
+"""File upload hardening: malware scanning and image sanitization.
+
+Scan order (called from POST /scan):
+  1. ClamAV antivirus scan   — optional, controlled by CLAMAV_ENABLED setting
+  2. Pillow re-encode        — always on; strips EXIF/XMP/IPTC and neutralises
+                               polyglot payloads by re-encoding to JPEG
+
+Both steps operate on raw bytes before they reach OpenAI.  The sanitizer
+also normalises all accepted formats (JPEG/PNG/WebP/HEIC) to JPEG, which
+is consistent with the hardcoded data:image/jpeg MIME type already sent to
+the Vision API.
+"""
+
+import io
+import logging
+
+from fastapi import HTTPException, status
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# ClamAV scan (optional)
+# ---------------------------------------------------------------------------
+
+
+def scan_for_malware(raw_bytes: bytes) -> None:
+    """Stream *raw_bytes* through the ClamAV daemon if CLAMAV_ENABLED is set.
+
+    Raises:
+        HTTPException 422  — if ClamAV reports a threat (FOUND)
+        HTTPException 503  — if the daemon is unreachable (fail-closed)
+    """
+    if not settings.clamav_enabled:
+        return
+
+    try:
+        import clamd  # type: ignore[import-untyped]
+    except ImportError:
+        logger.error("pyclamd is not installed but CLAMAV_ENABLED=true")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Malware scanning unavailable",
+        )
+
+    try:
+        cd = clamd.ClamdNetworkSocket(
+            host=settings.clamav_host,
+            port=settings.clamav_port,
+            timeout=10,
+        )
+        result = cd.instream(io.BytesIO(raw_bytes))
+    except Exception as exc:
+        logger.error("ClamAV daemon unreachable: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Malware scanning unavailable",
+        )
+
+    status_code, virus_name = result.get("stream", ("ERROR", "unknown"))
+    if status_code == "FOUND":
+        logger.warning("ClamAV detected threat: %s", virus_name)
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="File failed malware scan",
+        )
+    if status_code == "ERROR":
+        logger.error("ClamAV returned scan error: %s", virus_name)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Malware scanning unavailable",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Pillow image sanitization (always on)
+# ---------------------------------------------------------------------------
+
+
+def sanitize_image(raw_bytes: bytes) -> bytes:
+    """Re-encode *raw_bytes* as JPEG using Pillow.
+
+    Strips all embedded metadata (EXIF, XMP, IPTC, ICC profiles, comments)
+    and neutralises polyglot payloads by forcing a clean re-encode.
+
+    Outputs JPEG regardless of input format so the bytes are consistent with
+    the ``data:image/jpeg`` MIME type already sent to the OpenAI Vision API.
+
+    Falls back to the original bytes if Pillow cannot decode the image (e.g.
+    HEIC without the pillow-heif plugin installed).  Magic-bytes validation
+    has already confirmed the file is a genuine image at this point.
+
+    Returns:
+        Sanitized JPEG bytes, or *raw_bytes* unchanged if Pillow decoding fails.
+    """
+    try:
+        from PIL import Image, UnidentifiedImageError  # type: ignore[import-untyped]
+
+        buf = io.BytesIO(raw_bytes)
+        try:
+            img = Image.open(buf)
+            img.load()  # fully decode — catches truncated files
+        except UnidentifiedImageError:
+            # Pillow cannot handle this format (e.g. HEIC without pillow-heif).
+            # The file is already magic-byte validated; pass through unchanged.
+            logger.debug("Pillow could not decode image; skipping sanitization")
+            return raw_bytes
+
+        # Convert to RGB — required for JPEG output (no alpha channel support).
+        # PNG/WebP may carry RGBA or P (palette) modes.
+        if img.mode not in ("RGB", "L"):
+            img = img.convert("RGB")
+
+        out = io.BytesIO()
+        # quality=85 is visually lossless for book-cover thumbnails and keeps
+        # file size reasonable for the OpenAI Vision API payload limit.
+        img.save(out, format="JPEG", quality=85, optimize=True)
+        sanitized = out.getvalue()
+
+        logger.debug(
+            "Image sanitized: %d bytes → %d bytes JPEG", len(raw_bytes), len(sanitized)
+        )
+        return sanitized
+
+    except ImportError:
+        # Pillow is not installed.  Log loudly — requirements.txt should include it.
+        logger.error("Pillow is not installed; image sanitization skipped")
+        return raw_bytes

--- a/backend/app/core/file_security.py
+++ b/backend/app/core/file_security.py
@@ -102,9 +102,12 @@ def sanitize_image(raw_bytes: bytes) -> bytes:
         try:
             img = Image.open(buf)
             img.load()  # fully decode — catches truncated files
-        except UnidentifiedImageError:
-            # Pillow cannot handle this format (e.g. HEIC without pillow-heif).
-            # The file is already magic-byte validated; pass through unchanged.
+        except (UnidentifiedImageError, OSError):
+            # UnidentifiedImageError: Pillow cannot handle this format (e.g. HEIC
+            #   without pillow-heif installed).
+            # OSError: image file is truncated or otherwise unreadable by Pillow.
+            # In both cases the file has already passed magic-bytes validation so
+            # it is a genuine image; pass through the original bytes unchanged.
             logger.debug("Pillow could not decode image; skipping sanitization")
             return raw_bytes
 

--- a/backend/app/core/url_validator.py
+++ b/backend/app/core/url_validator.py
@@ -15,25 +15,25 @@ from urllib.parse import urlparse
 # Private and reserved IP networks per RFC 1918, RFC 4291, RFC 3927, etc.
 _BLOCKED_NETWORKS: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = [
     # IPv4
-    ipaddress.IPv4Network("127.0.0.0/8"),       # loopback
-    ipaddress.IPv4Network("10.0.0.0/8"),        # RFC 1918 private
-    ipaddress.IPv4Network("172.16.0.0/12"),     # RFC 1918 private
-    ipaddress.IPv4Network("192.168.0.0/16"),    # RFC 1918 private
-    ipaddress.IPv4Network("169.254.0.0/16"),    # link-local / cloud metadata
-    ipaddress.IPv4Network("0.0.0.0/8"),         # "this" network
-    ipaddress.IPv4Network("100.64.0.0/10"),     # shared address space (RFC 6598)
-    ipaddress.IPv4Network("192.0.0.0/24"),      # IETF protocol assignments
-    ipaddress.IPv4Network("198.18.0.0/15"),     # benchmarking (RFC 2544)
-    ipaddress.IPv4Network("198.51.100.0/24"),   # TEST-NET-2 (RFC 5737)
-    ipaddress.IPv4Network("203.0.113.0/24"),    # TEST-NET-3 (RFC 5737)
-    ipaddress.IPv4Network("240.0.0.0/4"),       # reserved (RFC 1112)
-    ipaddress.IPv4Network("255.255.255.255/32"),# broadcast
+    ipaddress.IPv4Network("127.0.0.0/8"),  # loopback
+    ipaddress.IPv4Network("10.0.0.0/8"),  # RFC 1918 private
+    ipaddress.IPv4Network("172.16.0.0/12"),  # RFC 1918 private
+    ipaddress.IPv4Network("192.168.0.0/16"),  # RFC 1918 private
+    ipaddress.IPv4Network("169.254.0.0/16"),  # link-local / cloud metadata
+    ipaddress.IPv4Network("0.0.0.0/8"),  # "this" network
+    ipaddress.IPv4Network("100.64.0.0/10"),  # shared address space (RFC 6598)
+    ipaddress.IPv4Network("192.0.0.0/24"),  # IETF protocol assignments
+    ipaddress.IPv4Network("198.18.0.0/15"),  # benchmarking (RFC 2544)
+    ipaddress.IPv4Network("198.51.100.0/24"),  # TEST-NET-2 (RFC 5737)
+    ipaddress.IPv4Network("203.0.113.0/24"),  # TEST-NET-3 (RFC 5737)
+    ipaddress.IPv4Network("240.0.0.0/4"),  # reserved (RFC 1112)
+    ipaddress.IPv4Network("255.255.255.255/32"),  # broadcast
     # IPv6
-    ipaddress.IPv6Network("::1/128"),           # loopback
-    ipaddress.IPv6Network("fc00::/7"),          # unique local (RFC 4193)
-    ipaddress.IPv6Network("fe80::/10"),         # link-local
-    ipaddress.IPv6Network("::ffff:0:0/96"),     # IPv4-mapped
-    ipaddress.IPv6Network("::/128"),            # unspecified
+    ipaddress.IPv6Network("::1/128"),  # loopback
+    ipaddress.IPv6Network("fc00::/7"),  # unique local (RFC 4193)
+    ipaddress.IPv6Network("fe80::/10"),  # link-local
+    ipaddress.IPv6Network("::ffff:0:0/96"),  # IPv4-mapped
+    ipaddress.IPv6Network("::/128"),  # unspecified
 ]
 
 

--- a/backend/app/core/url_validator.py
+++ b/backend/app/core/url_validator.py
@@ -1,0 +1,79 @@
+"""SSRF-safe URL validation for user-supplied URL fields.
+
+Validates that a URL:
+  1. Uses the https:// scheme only
+  2. Resolves to a public IP address (not private/loopback/link-local/reserved)
+
+Raises ValueError on any violation so Pydantic wraps it as a 422 response.
+"""
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+
+# Private and reserved IP networks per RFC 1918, RFC 4291, RFC 3927, etc.
+_BLOCKED_NETWORKS: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = [
+    # IPv4
+    ipaddress.IPv4Network("127.0.0.0/8"),       # loopback
+    ipaddress.IPv4Network("10.0.0.0/8"),        # RFC 1918 private
+    ipaddress.IPv4Network("172.16.0.0/12"),     # RFC 1918 private
+    ipaddress.IPv4Network("192.168.0.0/16"),    # RFC 1918 private
+    ipaddress.IPv4Network("169.254.0.0/16"),    # link-local / cloud metadata
+    ipaddress.IPv4Network("0.0.0.0/8"),         # "this" network
+    ipaddress.IPv4Network("100.64.0.0/10"),     # shared address space (RFC 6598)
+    ipaddress.IPv4Network("192.0.0.0/24"),      # IETF protocol assignments
+    ipaddress.IPv4Network("198.18.0.0/15"),     # benchmarking (RFC 2544)
+    ipaddress.IPv4Network("198.51.100.0/24"),   # TEST-NET-2 (RFC 5737)
+    ipaddress.IPv4Network("203.0.113.0/24"),    # TEST-NET-3 (RFC 5737)
+    ipaddress.IPv4Network("240.0.0.0/4"),       # reserved (RFC 1112)
+    ipaddress.IPv4Network("255.255.255.255/32"),# broadcast
+    # IPv6
+    ipaddress.IPv6Network("::1/128"),           # loopback
+    ipaddress.IPv6Network("fc00::/7"),          # unique local (RFC 4193)
+    ipaddress.IPv6Network("fe80::/10"),         # link-local
+    ipaddress.IPv6Network("::ffff:0:0/96"),     # IPv4-mapped
+    ipaddress.IPv6Network("::/128"),            # unspecified
+]
+
+
+def _is_private_ip(ip_str: str) -> bool:
+    try:
+        addr = ipaddress.ip_address(ip_str)
+        return any(addr in net for net in _BLOCKED_NETWORKS)
+    except ValueError:
+        return True  # unparseable — treat as unsafe
+
+
+def validate_safe_url(url: str | None) -> str | None:
+    """Validate a user-supplied URL is https and resolves to a public IP.
+
+    Returns the URL unchanged if valid; raises ValueError if not.
+    Intended for use as a Pydantic field_validator.
+    """
+    if url is None:
+        return url
+
+    parsed = urlparse(url)
+
+    if parsed.scheme != "https":
+        raise ValueError("URL must use the https scheme")
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise ValueError("URL must include a valid hostname")
+
+    try:
+        results = socket.getaddrinfo(hostname, None, proto=socket.IPPROTO_TCP)
+    except OSError:
+        # DNS resolution failed — reject rather than skip validation
+        raise ValueError(f"Could not resolve hostname: {hostname}")
+
+    for _family, _type, _proto, _canonname, sockaddr in results:
+        ip = sockaddr[0]
+        if _is_private_ip(ip):
+            raise ValueError(
+                "URL resolves to a private or reserved IP address and is not allowed"
+            )
+
+    return url

--- a/backend/app/core/url_validator.py
+++ b/backend/app/core/url_validator.py
@@ -11,7 +11,6 @@ import ipaddress
 import socket
 from urllib.parse import urlparse
 
-
 # Private and reserved IP networks per RFC 1918, RFC 4291, RFC 3927, etc.
 _BLOCKED_NETWORKS: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = [
     # IPv4

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -26,6 +26,7 @@ from app.core.database import AsyncSessionLocal
 from app.core.limiter import limiter
 from app.core.logging import configure_logging, new_request_id, request_id_var
 from app.core.sentry_context import SentryContextMiddleware
+from app.services.token_cleanup import cleanup_expired_tokens
 
 configure_logging()
 
@@ -129,7 +130,13 @@ async def _validate_config() -> None:
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     await _validate_config()
+    cleanup_task = asyncio.create_task(cleanup_expired_tokens())
     yield
+    cleanup_task.cancel()
+    try:
+        await cleanup_task
+    except asyncio.CancelledError:
+        pass
 
 
 app = FastAPI(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import hmac
 import logging
 from contextlib import asynccontextmanager

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,6 @@
 import hmac
 import logging
+from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
 
 import sentry_sdk
@@ -115,11 +116,28 @@ class RequestSizeLimitMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
 
+async def _validate_config() -> None:
+    """Fail fast on misconfigured deployments before any request is served."""
+    if settings.turnstile_required and not settings.turnstile_secret_key:
+        raise RuntimeError(
+            "TURNSTILE_SECRET_KEY must be configured when TURNSTILE_REQUIRED=true. "
+            "Set TURNSTILE_REQUIRED=false to explicitly disable bot protection "
+            "(dev / test environments only)."
+        )
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    await _validate_config()
+    yield
+
+
 app = FastAPI(
     title="Bookshelf API",
     version="0.1.0",
     docs_url="/docs" if settings.environment != "production" else None,
     redoc_url=None,
+    lifespan=lifespan,
 )
 
 

--- a/backend/app/schemas/book.py
+++ b/backend/app/schemas/book.py
@@ -4,19 +4,19 @@ import uuid
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class EditionBase(BaseModel):
-    isbn_13: str | None = None
-    isbn_10: str | None = None
-    publisher: str | None = None
+    isbn_13: str | None = Field(None, max_length=13)
+    isbn_10: str | None = Field(None, max_length=10)
+    publisher: str | None = Field(None, max_length=500)
     publish_year: int | None = None
     format: (
         Literal["hardcover", "paperback", "ebook", "audiobook", "unknown"] | None
     ) = None
     page_count: int | None = None
-    open_library_edition_id: str | None = None
+    open_library_edition_id: str | None = Field(None, max_length=50)
 
 
 class EditionRead(EditionBase):
@@ -34,12 +34,12 @@ class EditionPreview(EditionBase):
 
 
 class BookBase(BaseModel):
-    title: str
-    author: str
-    description: str | None = None
-    cover_url: str | None = None
+    title: str = Field(..., min_length=1, max_length=500)
+    author: str = Field(..., min_length=1, max_length=500)
+    description: str | None = Field(None, max_length=5000)
+    cover_url: str | None = Field(None, max_length=2048)
     subjects: list[str] | None = None
-    language: str = "en"
+    language: str = Field("en", max_length=10)
 
 
 class BookRead(BookBase):
@@ -57,12 +57,12 @@ class EnrichedBook(BaseModel):
     """Returned by POST /scan and GET /books/search."""
 
     book_id: uuid.UUID | None = None  # null if not yet in DB
-    open_library_work_id: str | None = None
-    google_books_id: str | None = None
-    title: str
-    author: str
-    description: str | None = None
-    cover_url: str | None = None
+    open_library_work_id: str | None = Field(None, max_length=50)
+    google_books_id: str | None = Field(None, max_length=50)
+    title: str = Field(..., max_length=500)
+    author: str = Field(..., max_length=500)
+    description: str | None = Field(None, max_length=5000)
+    cover_url: str | None = Field(None, max_length=2048)
     subjects: list[str] = []
     confidence: float  # 0–1, from image recognition
     already_in_library: bool = False

--- a/backend/app/schemas/user_book.py
+++ b/backend/app/schemas/user_book.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 from app.schemas.book import BookRead, EditionPreview, EditionRead
 
@@ -14,12 +14,12 @@ BookStatus = Literal["wishlisted", "purchased", "reading", "read"]
 class WishlistRequest(BaseModel):
     """Body for POST /wishlist — full book data from scan (book may not exist in DB yet)."""
 
-    open_library_work_id: str | None = None
-    google_books_id: str | None = None
-    title: str
-    author: str
-    description: str | None = None
-    cover_url: str | None = None
+    open_library_work_id: str | None = Field(None, max_length=50)
+    google_books_id: str | None = Field(None, max_length=50)
+    title: str = Field(..., min_length=1, max_length=500)
+    author: str = Field(..., min_length=1, max_length=500)
+    description: str | None = Field(None, max_length=5000)
+    cover_url: str | None = Field(None, max_length=2048)
     subjects: list[str] = []
     editions: list["EditionPreview"] = []  # noqa: F821
 
@@ -43,7 +43,7 @@ class UserBookUpdate(BaseModel):
     """Body for PATCH /user-books/{id}."""
 
     status: BookStatus | None = None
-    notes: str | None = None
+    notes: str | None = Field(None, max_length=10000)
     rating: int | None = None
 
     @field_validator("rating")

--- a/backend/app/schemas/user_book.py
+++ b/backend/app/schemas/user_book.py
@@ -6,6 +6,7 @@ from typing import Literal
 
 from pydantic import BaseModel, Field, field_validator
 
+from app.core.url_validator import validate_safe_url
 from app.schemas.book import BookRead, EditionPreview, EditionRead
 
 BookStatus = Literal["wishlisted", "purchased", "reading", "read"]
@@ -22,6 +23,11 @@ class WishlistRequest(BaseModel):
     cover_url: str | None = Field(None, max_length=2048)
     subjects: list[str] = []
     editions: list["EditionPreview"] = []  # noqa: F821
+
+    @field_validator("cover_url", mode="before")
+    @classmethod
+    def cover_url_must_be_safe(cls, v: str | None) -> str | None:
+        return validate_safe_url(v)
 
 
 class UserBookCreate(BaseModel):

--- a/backend/app/services/token_cleanup.py
+++ b/backend/app/services/token_cleanup.py
@@ -1,0 +1,46 @@
+"""Background task: periodically delete expired refresh tokens.
+
+Expired tokens (expires_at < now) can never be used regardless of their
+revocation status, so they are safe to remove.  Keeping them indefinitely
+causes unbounded table growth and slows the JTI revocation lookup index.
+
+The task runs once at startup (with an initial delay) then every 24 hours.
+It is launched inside the FastAPI lifespan and cancelled on shutdown.
+"""
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+
+from sqlalchemy import delete
+
+from app.core.database import AsyncSessionLocal
+from app.models.refresh_token import RefreshToken
+
+logger = logging.getLogger(__name__)
+
+_INTERVAL_SECONDS = 86_400  # 24 hours
+_INITIAL_DELAY_SECONDS = 60  # wait a minute after startup before first run
+
+
+async def cleanup_expired_tokens() -> None:
+    """Long-running coroutine; meant to be wrapped in asyncio.create_task()."""
+    await asyncio.sleep(_INITIAL_DELAY_SECONDS)
+
+    while True:
+        try:
+            async with AsyncSessionLocal() as db:
+                result = await db.execute(
+                    delete(RefreshToken).where(
+                        RefreshToken.expires_at < datetime.now(timezone.utc)
+                    )
+                )
+                await db.commit()
+                logger.info(
+                    "token_cleanup: deleted %d expired refresh token(s)",
+                    result.rowcount,
+                )
+        except Exception:
+            logger.exception("token_cleanup: error during cleanup run")
+
+        await asyncio.sleep(_INTERVAL_SECONDS)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,3 +14,5 @@ python-multipart==0.0.24
 cryptography>=43.0.0
 sentry-sdk[fastapi]==2.57.0
 jinja2>=3.1.0
+Pillow>=11.0.0
+pyclamd>=0.4.0

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -10,6 +10,11 @@ _DUMMY_DB_URL = "postgresql+asyncpg://test:test@localhost/test"
 if not os.environ.get("DATABASE_URL"):
     os.environ["DATABASE_URL"] = _DUMMY_DB_URL
 
+# Disable Turnstile bot-protection in tests. Production deployments must configure
+# TURNSTILE_SECRET_KEY; the startup handler enforces this when TURNSTILE_REQUIRED=true.
+if not os.environ.get("TURNSTILE_REQUIRED"):
+    os.environ["TURNSTILE_REQUIRED"] = "false"
+
 
 def pytest_configure(config):
     """Register the 'integration' marker for DB integration tests."""

--- a/backend/tests/security/test_file_sanitization.py
+++ b/backend/tests/security/test_file_sanitization.py
@@ -5,7 +5,6 @@ pytest -m security -v tests/security/test_file_sanitization.py
 """
 
 import io
-import struct
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -42,7 +41,6 @@ def _make_webp(width: int = 10, height: int = 10) -> bytes:
 def _jpeg_with_exif() -> bytes:
     """Build a minimal JPEG that includes an EXIF GPS tag."""
     from PIL import Image
-    from PIL.ExifTags import TAGS
 
     buf = io.BytesIO()
     img = Image.new("RGB", (10, 10), color=(128, 128, 128))
@@ -112,9 +110,13 @@ class TestImageSanitization:
 
         from app.core.file_security import sanitize_image
 
-        garbage = b"\x00\x00\x00\x18ftypheic" + b"\x00" * 100  # minimal HEIC-like header
+        garbage = (
+            b"\x00\x00\x00\x18ftypheic" + b"\x00" * 100
+        )  # minimal HEIC-like header
 
-        with patch("PIL.Image.open", side_effect=UnidentifiedImageError("cannot identify")):
+        with patch(
+            "PIL.Image.open", side_effect=UnidentifiedImageError("cannot identify")
+        ):
             result = sanitize_image(garbage)
 
         assert result == garbage  # falls back to original
@@ -164,8 +166,10 @@ class TestClamAVScan:
         mock_cd = MagicMock()
         mock_cd.instream.return_value = {"stream": ("OK", None)}
 
-        with patch("app.core.file_security.settings") as mock_settings, \
-             patch.dict("sys.modules", {"clamd": MagicMock(ClamdNetworkSocket=MagicMock(return_value=mock_cd))}):
+        with patch("app.core.file_security.settings") as mock_settings, patch.dict(
+            "sys.modules",
+            {"clamd": MagicMock(ClamdNetworkSocket=MagicMock(return_value=mock_cd))},
+        ):
             mock_settings.clamav_enabled = True
             mock_settings.clamav_host = "localhost"
             mock_settings.clamav_port = 3310
@@ -178,8 +182,10 @@ class TestClamAVScan:
         mock_cd = MagicMock()
         mock_cd.instream.return_value = {"stream": ("FOUND", "Eicar-Test-Signature")}
 
-        with patch("app.core.file_security.settings") as mock_settings, \
-             patch.dict("sys.modules", {"clamd": MagicMock(ClamdNetworkSocket=MagicMock(return_value=mock_cd))}):
+        with patch("app.core.file_security.settings") as mock_settings, patch.dict(
+            "sys.modules",
+            {"clamd": MagicMock(ClamdNetworkSocket=MagicMock(return_value=mock_cd))},
+        ):
             mock_settings.clamav_enabled = True
             mock_settings.clamav_host = "localhost"
             mock_settings.clamav_port = 3310
@@ -196,10 +202,13 @@ class TestClamAVScan:
         from app.core.file_security import scan_for_malware
 
         mock_clamd = MagicMock()
-        mock_clamd.ClamdNetworkSocket.side_effect = ConnectionRefusedError("daemon down")
+        mock_clamd.ClamdNetworkSocket.side_effect = ConnectionRefusedError(
+            "daemon down"
+        )
 
-        with patch("app.core.file_security.settings") as mock_settings, \
-             patch.dict("sys.modules", {"clamd": mock_clamd}):
+        with patch("app.core.file_security.settings") as mock_settings, patch.dict(
+            "sys.modules", {"clamd": mock_clamd}
+        ):
             mock_settings.clamav_enabled = True
             mock_settings.clamav_host = "localhost"
             mock_settings.clamav_port = 3310

--- a/backend/tests/security/test_file_sanitization.py
+++ b/backend/tests/security/test_file_sanitization.py
@@ -11,7 +11,6 @@ import pytest
 from fastapi import HTTPException
 from PIL import Image
 
-
 # ---------------------------------------------------------------------------
 # Helpers — build minimal valid image bytes in memory
 # ---------------------------------------------------------------------------

--- a/backend/tests/security/test_file_sanitization.py
+++ b/backend/tests/security/test_file_sanitization.py
@@ -1,0 +1,210 @@
+"""
+Security tests for image sanitization and ClamAV malware scanning.
+
+pytest -m security -v tests/security/test_file_sanitization.py
+"""
+
+import io
+import struct
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from PIL import Image
+
+
+# ---------------------------------------------------------------------------
+# Helpers — build minimal valid image bytes in memory
+# ---------------------------------------------------------------------------
+
+
+def _make_jpeg(width: int = 10, height: int = 10) -> bytes:
+    buf = io.BytesIO()
+    img = Image.new("RGB", (width, height), color=(255, 0, 0))
+    img.save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+def _make_png(width: int = 10, height: int = 10, mode: str = "RGB") -> bytes:
+    buf = io.BytesIO()
+    img = Image.new(mode, (width, height), color=(0, 255, 0))
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _make_webp(width: int = 10, height: int = 10) -> bytes:
+    buf = io.BytesIO()
+    img = Image.new("RGB", (width, height), color=(0, 0, 255))
+    img.save(buf, format="WEBP")
+    return buf.getvalue()
+
+
+def _jpeg_with_exif() -> bytes:
+    """Build a minimal JPEG that includes an EXIF GPS tag."""
+    from PIL import Image
+    from PIL.ExifTags import TAGS
+
+    buf = io.BytesIO()
+    img = Image.new("RGB", (10, 10), color=(128, 128, 128))
+    exif = img.getexif()
+    # Tag 0x0112 = Orientation (safe, always present in real cameras)
+    exif[0x0112] = 6
+    img.save(buf, format="JPEG", exif=exif.tobytes())
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# A04 — Image sanitization (Pillow re-encode, always on)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.security
+class TestImageSanitization:
+    """Pillow re-encode must strip metadata and always produce valid JPEG output."""
+
+    def test_jpeg_sanitized_is_valid_jpeg(self) -> None:
+        from app.core.file_security import sanitize_image
+
+        result = sanitize_image(_make_jpeg())
+        assert result[:3] == b"\xff\xd8\xff"  # JPEG magic bytes
+
+    def test_png_sanitized_to_jpeg(self) -> None:
+        from app.core.file_security import sanitize_image
+
+        png_bytes = _make_png()
+        result = sanitize_image(png_bytes)
+        # Output must be JPEG regardless of input format
+        assert result[:3] == b"\xff\xd8\xff"
+
+    def test_webp_sanitized_to_jpeg(self) -> None:
+        from app.core.file_security import sanitize_image
+
+        result = sanitize_image(_make_webp())
+        assert result[:3] == b"\xff\xd8\xff"
+
+    def test_rgba_png_converted_without_error(self) -> None:
+        """RGBA PNG (has alpha channel) must be downconverted to RGB before JPEG save."""
+        from app.core.file_security import sanitize_image
+
+        result = sanitize_image(_make_png(mode="RGBA"))
+        assert result[:3] == b"\xff\xd8\xff"
+
+    def test_exif_stripped_after_sanitization(self) -> None:
+        """EXIF metadata present in the source image must not appear in the output."""
+        from app.core.file_security import sanitize_image
+
+        dirty = _jpeg_with_exif()
+
+        # Confirm EXIF is present in original (APP1 marker = FF E1)
+        assert b"\xff\xe1" in dirty
+
+        clean = sanitize_image(dirty)
+
+        # Re-open and confirm no EXIF
+        img = Image.open(io.BytesIO(clean))
+        exif = img.getexif()
+        assert len(exif) == 0, f"Expected no EXIF after sanitization, got: {dict(exif)}"
+
+    def test_unrecognised_format_falls_back_to_original(self) -> None:
+        """If Pillow cannot decode the bytes (e.g. HEIC without pillow-heif),
+        the original bytes must be returned unchanged — not an exception."""
+        from PIL import UnidentifiedImageError
+
+        from app.core.file_security import sanitize_image
+
+        garbage = b"\x00\x00\x00\x18ftypheic" + b"\x00" * 100  # minimal HEIC-like header
+
+        with patch("PIL.Image.open", side_effect=UnidentifiedImageError("cannot identify")):
+            result = sanitize_image(garbage)
+
+        assert result == garbage  # falls back to original
+
+    def test_sanitized_image_is_openable_by_pillow(self) -> None:
+        """The sanitized output must be a valid image Pillow can fully round-trip."""
+        from app.core.file_security import sanitize_image
+
+        result = sanitize_image(_make_jpeg())
+        img = Image.open(io.BytesIO(result))
+        img.load()
+        assert img.format == "JPEG"
+
+    def test_sanitize_reduces_or_equal_size_for_simple_image(self) -> None:
+        """A plain colour JPEG should not grow dramatically after sanitization."""
+        from app.core.file_security import sanitize_image
+
+        original = _make_jpeg(width=100, height=100)
+        result = sanitize_image(original)
+        # Allow up to 2× growth (re-encoding complex images can be slightly larger)
+        assert len(result) <= len(original) * 2
+
+
+# ---------------------------------------------------------------------------
+# A04 — ClamAV scan (optional, env-gated)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.security
+class TestClamAVScan:
+    """ClamAV scanning must be a no-op when disabled and fail-closed when enabled."""
+
+    def test_scan_skipped_when_disabled(self) -> None:
+        """With CLAMAV_ENABLED=false, scan_for_malware must return without error
+        and without importing or calling clamd."""
+        from app.core.file_security import scan_for_malware
+
+        with patch("app.core.file_security.settings") as mock_settings:
+            mock_settings.clamav_enabled = False
+            # Should complete without raising — no clamd import needed
+            scan_for_malware(b"any bytes")
+
+    def test_scan_passes_clean_file(self) -> None:
+        """When ClamAV is enabled and reports OK, no exception is raised."""
+        from app.core.file_security import scan_for_malware
+
+        mock_cd = MagicMock()
+        mock_cd.instream.return_value = {"stream": ("OK", None)}
+
+        with patch("app.core.file_security.settings") as mock_settings, \
+             patch.dict("sys.modules", {"clamd": MagicMock(ClamdNetworkSocket=MagicMock(return_value=mock_cd))}):
+            mock_settings.clamav_enabled = True
+            mock_settings.clamav_host = "localhost"
+            mock_settings.clamav_port = 3310
+            scan_for_malware(_make_jpeg())  # must not raise
+
+    def test_scan_raises_422_on_threat_found(self) -> None:
+        """When ClamAV reports FOUND, a 422 HTTPException must be raised."""
+        from app.core.file_security import scan_for_malware
+
+        mock_cd = MagicMock()
+        mock_cd.instream.return_value = {"stream": ("FOUND", "Eicar-Test-Signature")}
+
+        with patch("app.core.file_security.settings") as mock_settings, \
+             patch.dict("sys.modules", {"clamd": MagicMock(ClamdNetworkSocket=MagicMock(return_value=mock_cd))}):
+            mock_settings.clamav_enabled = True
+            mock_settings.clamav_host = "localhost"
+            mock_settings.clamav_port = 3310
+
+            with pytest.raises(HTTPException) as exc_info:
+                scan_for_malware(b"EICAR test payload")
+
+        assert exc_info.value.status_code == 422
+        assert "malware" in exc_info.value.detail.lower()
+
+    def test_scan_raises_503_when_daemon_unreachable(self) -> None:
+        """When the ClamAV daemon is down, a 503 HTTPException must be raised
+        (fail-closed: do not let uploads through if the scanner is broken)."""
+        from app.core.file_security import scan_for_malware
+
+        mock_clamd = MagicMock()
+        mock_clamd.ClamdNetworkSocket.side_effect = ConnectionRefusedError("daemon down")
+
+        with patch("app.core.file_security.settings") as mock_settings, \
+             patch.dict("sys.modules", {"clamd": mock_clamd}):
+            mock_settings.clamav_enabled = True
+            mock_settings.clamav_host = "localhost"
+            mock_settings.clamav_port = 3310
+
+            with pytest.raises(HTTPException) as exc_info:
+                scan_for_malware(_make_jpeg())
+
+        assert exc_info.value.status_code == 503

--- a/backend/tests/security/test_injection.py
+++ b/backend/tests/security/test_injection.py
@@ -367,3 +367,66 @@ class TestAuthBypassAttempts:
         )
         # FastAPI's HTTPBearer rejects non-Bearer schemes with 401 or 403
         assert response.status_code in (401, 403)
+
+
+# ---------------------------------------------------------------------------
+# A03/A04 — Input length limits (schema-level enforcement)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.security
+class TestInputLengthLimits:
+    """
+    All user-supplied string fields must be bounded.
+    Exceeding max_length must raise Pydantic ValidationError at the schema layer
+    before any business logic or database query is reached.
+    """
+
+    def test_wishlist_title_too_long(self) -> None:
+        with pytest.raises(ValidationError):
+            WishlistRequest(title="a" * 501, author="Author")
+
+    def test_wishlist_title_at_limit_accepted(self) -> None:
+        req = WishlistRequest(title="a" * 500, author="Author")
+        assert len(req.title) == 500
+
+    def test_wishlist_author_too_long(self) -> None:
+        with pytest.raises(ValidationError):
+            WishlistRequest(title="Title", author="a" * 501)
+
+    def test_wishlist_author_at_limit_accepted(self) -> None:
+        req = WishlistRequest(title="Title", author="a" * 500)
+        assert len(req.author) == 500
+
+    def test_wishlist_description_too_long(self) -> None:
+        with pytest.raises(ValidationError):
+            WishlistRequest(title="Title", author="Author", description="a" * 5001)
+
+    def test_wishlist_description_at_limit_accepted(self) -> None:
+        req = WishlistRequest(title="Title", author="Author", description="a" * 5000)
+        assert req.description is not None and len(req.description) == 5000
+
+    def test_wishlist_cover_url_too_long(self) -> None:
+        with pytest.raises(ValidationError):
+            WishlistRequest(title="Title", author="Author", cover_url="https://x.com/" + "a" * 2040)
+
+    def test_wishlist_cover_url_at_limit_accepted(self) -> None:
+        url = "https://x.com/" + "a" * (2048 - len("https://x.com/"))
+        req = WishlistRequest(title="Title", author="Author", cover_url=url)
+        assert req.cover_url is not None and len(req.cover_url) == 2048
+
+    def test_user_book_update_notes_too_long(self) -> None:
+        with pytest.raises(ValidationError):
+            UserBookUpdate(notes="a" * 10001)
+
+    def test_user_book_update_notes_at_limit_accepted(self) -> None:
+        update = UserBookUpdate(notes="a" * 10000)
+        assert update.notes is not None and len(update.notes) == 10000
+
+    def test_wishlist_empty_title_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            WishlistRequest(title="", author="Author")
+
+    def test_wishlist_empty_author_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            WishlistRequest(title="Title", author="")

--- a/backend/tests/security/test_injection.py
+++ b/backend/tests/security/test_injection.py
@@ -12,6 +12,7 @@ from fastapi.testclient import TestClient
 from pydantic import ValidationError
 
 from app.main import app  # noqa: F401 — side-effect: registers routers and middleware
+from app.core.url_validator import validate_safe_url
 from app.schemas.user_book import UserBookUpdate, WishlistRequest
 
 # ---------------------------------------------------------------------------
@@ -430,3 +431,58 @@ class TestInputLengthLimits:
     def test_wishlist_empty_author_rejected(self) -> None:
         with pytest.raises(ValidationError):
             WishlistRequest(title="Title", author="")
+
+
+# ---------------------------------------------------------------------------
+# A10 — SSRF prevention on user-supplied URL fields
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.security
+class TestSSRFPrevention:
+    """
+    User-supplied URLs must resolve to public IPs only.
+    Private, loopback, and link-local addresses must be rejected with a
+    Pydantic ValidationError (→ 422 at the HTTP layer).
+    """
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://127.0.0.1/secret",
+            "https://127.0.0.1:8080/admin",
+            "https://10.0.0.1/internal",
+            "https://10.255.255.255/internal",
+            "https://172.16.0.1/private",
+            "https://172.31.255.255/private",
+            "https://192.168.1.1/router",
+            "https://169.254.169.254/latest/meta-data/",   # AWS metadata
+            "https://169.254.169.254/computeMetadata/v1/", # GCP metadata
+        ],
+    )
+    def test_private_ip_urls_rejected(self, url: str) -> None:
+        with pytest.raises(ValueError, match="private or reserved"):
+            validate_safe_url(url)
+
+    def test_http_scheme_rejected(self) -> None:
+        with pytest.raises(ValueError, match="https"):
+            validate_safe_url("http://example.com/cover.jpg")
+
+    def test_ftp_scheme_rejected(self) -> None:
+        with pytest.raises(ValueError, match="https"):
+            validate_safe_url("ftp://example.com/cover.jpg")
+
+    def test_none_is_allowed(self) -> None:
+        assert validate_safe_url(None) is None
+
+    def test_private_ip_rejected_via_schema(self) -> None:
+        with pytest.raises(ValidationError):
+            WishlistRequest(
+                title="Title",
+                author="Author",
+                cover_url="https://192.168.1.1/cover.jpg",
+            )
+
+    def test_missing_hostname_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            validate_safe_url("https:///no-host")

--- a/backend/tests/security/test_injection.py
+++ b/backend/tests/security/test_injection.py
@@ -486,3 +486,79 @@ class TestSSRFPrevention:
     def test_missing_hostname_rejected(self) -> None:
         with pytest.raises(ValueError):
             validate_safe_url("https:///no-host")
+
+
+# ---------------------------------------------------------------------------
+# A05 — Turnstile required by default (misconfiguration guard)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.security
+class TestTurnstileRequired:
+    """
+    The startup validator must prevent the app from serving requests when
+    TURNSTILE_REQUIRED=true but no secret key is configured.
+    When disabled explicitly (TURNSTILE_REQUIRED=false), startup succeeds
+    regardless of whether a key is present.
+    """
+
+    def test_startup_raises_when_required_and_no_key(self) -> None:
+        """Startup must raise RuntimeError when Turnstile is required but unconfigured."""
+        import asyncio
+        from unittest.mock import patch
+
+        from app.core.config import Settings
+
+        cfg = Settings(
+            database_url="postgresql+asyncpg://u:p@localhost/db",
+            turnstile_required=True,
+            turnstile_secret_key="",
+        )
+
+        async def _run():
+            from app.main import _validate_config
+            with patch("app.main.settings", cfg):
+                await _validate_config()
+
+        with pytest.raises(RuntimeError, match="TURNSTILE_SECRET_KEY"):
+            asyncio.run(_run())
+
+    def test_startup_succeeds_when_required_and_key_present(self) -> None:
+        """Startup must not raise when Turnstile is required and key is configured."""
+        import asyncio
+        from unittest.mock import patch
+
+        from app.core.config import Settings
+
+        cfg = Settings(
+            database_url="postgresql+asyncpg://u:p@localhost/db",
+            turnstile_required=True,
+            turnstile_secret_key="a-real-secret-key",
+        )
+
+        async def _run():
+            from app.main import _validate_config
+            with patch("app.main.settings", cfg):
+                await _validate_config()
+
+        asyncio.run(_run())  # must not raise
+
+    def test_startup_succeeds_when_explicitly_disabled(self) -> None:
+        """TURNSTILE_REQUIRED=false must allow startup even with no key."""
+        import asyncio
+        from unittest.mock import patch
+
+        from app.core.config import Settings
+
+        cfg = Settings(
+            database_url="postgresql+asyncpg://u:p@localhost/db",
+            turnstile_required=False,
+            turnstile_secret_key="",
+        )
+
+        async def _run():
+            from app.main import _validate_config
+            with patch("app.main.settings", cfg):
+                await _validate_config()
+
+        asyncio.run(_run())  # must not raise

--- a/backend/tests/security/test_injection.py
+++ b/backend/tests/security/test_injection.py
@@ -409,7 +409,9 @@ class TestInputLengthLimits:
 
     def test_wishlist_cover_url_too_long(self) -> None:
         with pytest.raises(ValidationError):
-            WishlistRequest(title="Title", author="Author", cover_url="https://x.com/" + "a" * 2040)
+            WishlistRequest(
+                title="Title", author="Author", cover_url="https://x.com/" + "a" * 2040
+            )
 
     def test_wishlist_cover_url_at_limit_accepted(self) -> None:
         url = "https://x.com/" + "a" * (2048 - len("https://x.com/"))
@@ -456,8 +458,8 @@ class TestSSRFPrevention:
             "https://172.16.0.1/private",
             "https://172.31.255.255/private",
             "https://192.168.1.1/router",
-            "https://169.254.169.254/latest/meta-data/",   # AWS metadata
-            "https://169.254.169.254/computeMetadata/v1/", # GCP metadata
+            "https://169.254.169.254/latest/meta-data/",  # AWS metadata
+            "https://169.254.169.254/computeMetadata/v1/",  # GCP metadata
         ],
     )
     def test_private_ip_urls_rejected(self, url: str) -> None:
@@ -517,6 +519,7 @@ class TestTurnstileRequired:
 
         async def _run():
             from app.main import _validate_config
+
             with patch("app.main.settings", cfg):
                 await _validate_config()
 
@@ -538,6 +541,7 @@ class TestTurnstileRequired:
 
         async def _run():
             from app.main import _validate_config
+
             with patch("app.main.settings", cfg):
                 await _validate_config()
 
@@ -558,6 +562,7 @@ class TestTurnstileRequired:
 
         async def _run():
             from app.main import _validate_config
+
             with patch("app.main.settings", cfg):
                 await _validate_config()
 

--- a/backend/tests/unit/test_scan_endpoint.py
+++ b/backend/tests/unit/test_scan_endpoint.py
@@ -129,9 +129,11 @@ class TestTurnstileProtection:
 
         with patch("app.api.scan.settings") as mock_settings:
             mock_settings.rate_limit_scan = "10/minute"
+            mock_settings.turnstile_required = True
             mock_settings.turnstile_secret_key = (
                 "0x0000000000000000000000000000000000000000"
             )
+            mock_settings.clamav_enabled = False
             yield TestClient(app), mock_settings
 
         app.dependency_overrides.clear()
@@ -169,8 +171,8 @@ class TestTurnstileProtection:
             )
         assert resp.status_code == 200
 
-    def test_skipped_when_secret_key_absent(self):
-        """When TURNSTILE_SECRET_KEY is not set, the check is skipped entirely."""
+    def test_skipped_when_turnstile_disabled(self):
+        """When TURNSTILE_REQUIRED=false, the check is skipped entirely."""
         from app.auth.dependencies import get_current_user
         from app.core.database import get_db
 
@@ -187,7 +189,8 @@ class TestTurnstileProtection:
             patch("app.api.scan.DeduplicationService"),
         ):
             mock_settings.rate_limit_scan = "10/minute"
-            mock_settings.turnstile_secret_key = ""  # key not configured
+            mock_settings.turnstile_required = False  # explicitly disabled
+            mock_settings.clamav_enabled = False
             mock_id_cls.return_value.identify = AsyncMock(return_value=[])
             client = TestClient(app)
             resp = client.post("/scan", files={"file": _image_file()})

--- a/backend/tests/unit/test_token_cleanup.py
+++ b/backend/tests/unit/test_token_cleanup.py
@@ -1,8 +1,7 @@
 """Unit tests for the refresh token cleanup background task."""
 
 import asyncio
-from datetime import datetime, timedelta, timezone
-from unittest.mock import AsyncMock, MagicMock, patch, call
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -30,13 +29,12 @@ class TestCleanupExpiredTokens:
     @pytest.mark.asyncio
     async def test_deletes_expired_tokens_and_logs(self, caplog) -> None:
         """A single cleanup run must execute a DELETE and commit."""
-        import logging
 
         mock_factory, mock_session, mock_result = _make_db_mock(rowcount=5)
 
-        with patch("app.services.token_cleanup.AsyncSessionLocal", mock_factory), \
-             patch("app.services.token_cleanup._INITIAL_DELAY_SECONDS", 0), \
-             patch("app.services.token_cleanup._INTERVAL_SECONDS", 0):
+        with patch("app.services.token_cleanup.AsyncSessionLocal", mock_factory), patch(
+            "app.services.token_cleanup._INITIAL_DELAY_SECONDS", 0
+        ), patch("app.services.token_cleanup._INTERVAL_SECONDS", 0):
 
             # Run two ticks then cancel
             with pytest.raises(asyncio.CancelledError):
@@ -52,15 +50,12 @@ class TestCleanupExpiredTokens:
     @pytest.mark.asyncio
     async def test_delete_filters_by_expires_at(self) -> None:
         """The DELETE statement must filter on expires_at < now."""
-        from sqlalchemy import delete as sa_delete
-
-        from app.models.refresh_token import RefreshToken
 
         mock_factory, mock_session, _ = _make_db_mock()
 
-        with patch("app.services.token_cleanup.AsyncSessionLocal", mock_factory), \
-             patch("app.services.token_cleanup._INITIAL_DELAY_SECONDS", 0), \
-             patch("app.services.token_cleanup._INTERVAL_SECONDS", 9999):
+        with patch("app.services.token_cleanup.AsyncSessionLocal", mock_factory), patch(
+            "app.services.token_cleanup._INITIAL_DELAY_SECONDS", 0
+        ), patch("app.services.token_cleanup._INTERVAL_SECONDS", 9999):
 
             with pytest.raises(asyncio.CancelledError):
                 task = asyncio.create_task(cleanup_expired_tokens())
@@ -94,10 +89,11 @@ class TestCleanupExpiredTokens:
         mock_factory, mock_session, _ = _make_db_mock()
         mock_session.execute = flaky_execute
 
-        with patch("app.services.token_cleanup.AsyncSessionLocal", mock_factory), \
-             patch("app.services.token_cleanup._INITIAL_DELAY_SECONDS", 0), \
-             patch("app.services.token_cleanup._INTERVAL_SECONDS", 0), \
-             caplog.at_level(logging.ERROR, logger="app.services.token_cleanup"):
+        with patch("app.services.token_cleanup.AsyncSessionLocal", mock_factory), patch(
+            "app.services.token_cleanup._INITIAL_DELAY_SECONDS", 0
+        ), patch("app.services.token_cleanup._INTERVAL_SECONDS", 0), caplog.at_level(
+            logging.ERROR, logger="app.services.token_cleanup"
+        ):
 
             with pytest.raises(asyncio.CancelledError):
                 task = asyncio.create_task(cleanup_expired_tokens())
@@ -116,8 +112,9 @@ class TestCleanupExpiredTokens:
         """asyncio.CancelledError must propagate so the lifespan can await the task."""
         mock_factory, mock_session, _ = _make_db_mock()
 
-        with patch("app.services.token_cleanup.AsyncSessionLocal", mock_factory), \
-             patch("app.services.token_cleanup._INITIAL_DELAY_SECONDS", 0):
+        with patch("app.services.token_cleanup.AsyncSessionLocal", mock_factory), patch(
+            "app.services.token_cleanup._INITIAL_DELAY_SECONDS", 0
+        ):
 
             task = asyncio.create_task(cleanup_expired_tokens())
             await asyncio.sleep(0)

--- a/backend/tests/unit/test_token_cleanup.py
+++ b/backend/tests/unit/test_token_cleanup.py
@@ -1,0 +1,127 @@
+"""Unit tests for the refresh token cleanup background task."""
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch, call
+
+import pytest
+
+from app.services.token_cleanup import cleanup_expired_tokens
+
+
+def _make_db_mock(rowcount: int = 3):
+    """Return an AsyncMock that mimics AsyncSessionLocal as an async context manager."""
+    mock_result = MagicMock()
+    mock_result.rowcount = rowcount
+
+    mock_session = AsyncMock()
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_session.commit = AsyncMock()
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+
+    mock_session_factory = MagicMock(return_value=mock_session)
+    return mock_session_factory, mock_session, mock_result
+
+
+class TestCleanupExpiredTokens:
+    """cleanup_expired_tokens must delete expired rows and handle errors gracefully."""
+
+    @pytest.mark.asyncio
+    async def test_deletes_expired_tokens_and_logs(self, caplog) -> None:
+        """A single cleanup run must execute a DELETE and commit."""
+        import logging
+
+        mock_factory, mock_session, mock_result = _make_db_mock(rowcount=5)
+
+        with patch("app.services.token_cleanup.AsyncSessionLocal", mock_factory), \
+             patch("app.services.token_cleanup._INITIAL_DELAY_SECONDS", 0), \
+             patch("app.services.token_cleanup._INTERVAL_SECONDS", 0):
+
+            # Run two ticks then cancel
+            with pytest.raises(asyncio.CancelledError):
+                task = asyncio.create_task(cleanup_expired_tokens())
+                await asyncio.sleep(0)  # let it start
+                await asyncio.sleep(0)  # let it run the first iteration
+                task.cancel()
+                await task
+
+        mock_session.execute.assert_called()
+        mock_session.commit.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_filters_by_expires_at(self) -> None:
+        """The DELETE statement must filter on expires_at < now."""
+        from sqlalchemy import delete as sa_delete
+
+        from app.models.refresh_token import RefreshToken
+
+        mock_factory, mock_session, _ = _make_db_mock()
+
+        with patch("app.services.token_cleanup.AsyncSessionLocal", mock_factory), \
+             patch("app.services.token_cleanup._INITIAL_DELAY_SECONDS", 0), \
+             patch("app.services.token_cleanup._INTERVAL_SECONDS", 9999):
+
+            with pytest.raises(asyncio.CancelledError):
+                task = asyncio.create_task(cleanup_expired_tokens())
+                await asyncio.sleep(0)
+                await asyncio.sleep(0)
+                task.cancel()
+                await task
+
+        # Confirm execute was called with a DELETE statement
+        assert mock_session.execute.called
+        stmt = mock_session.execute.call_args[0][0]
+        # SQLAlchemy Delete object targets the refresh_tokens table
+        assert "refresh_tokens" in str(stmt)
+
+    @pytest.mark.asyncio
+    async def test_continues_after_db_error(self, caplog) -> None:
+        """A database error must be logged and the task must keep running."""
+        import logging
+
+        call_count = 0
+
+        async def flaky_execute(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise Exception("connection lost")
+            result = MagicMock()
+            result.rowcount = 0
+            return result
+
+        mock_factory, mock_session, _ = _make_db_mock()
+        mock_session.execute = flaky_execute
+
+        with patch("app.services.token_cleanup.AsyncSessionLocal", mock_factory), \
+             patch("app.services.token_cleanup._INITIAL_DELAY_SECONDS", 0), \
+             patch("app.services.token_cleanup._INTERVAL_SECONDS", 0), \
+             caplog.at_level(logging.ERROR, logger="app.services.token_cleanup"):
+
+            with pytest.raises(asyncio.CancelledError):
+                task = asyncio.create_task(cleanup_expired_tokens())
+                # Let it run through the error and at least one successful pass
+                for _ in range(4):
+                    await asyncio.sleep(0)
+                task.cancel()
+                await task
+
+        assert "error during cleanup run" in caplog.text
+        # Verify it kept running past the error
+        assert call_count >= 2
+
+    @pytest.mark.asyncio
+    async def test_cancelled_error_propagates_cleanly(self) -> None:
+        """asyncio.CancelledError must propagate so the lifespan can await the task."""
+        mock_factory, mock_session, _ = _make_db_mock()
+
+        with patch("app.services.token_cleanup.AsyncSessionLocal", mock_factory), \
+             patch("app.services.token_cleanup._INITIAL_DELAY_SECONDS", 0):
+
+            task = asyncio.create_task(cleanup_expired_tokens())
+            await asyncio.sleep(0)
+            task.cancel()
+
+            with pytest.raises(asyncio.CancelledError):
+                await task


### PR DESCRIPTION
## Summary

Progressive security hardening across OWASP A01/A03/A04/A05/A07/A10. Issues are being landed as commits on this branch; each commit closes one issue.

| Commit | Issue | OWASP |
|---|---|---|
| Input length limits on all string fields | #226 | A03/A04 |
| SSRF prevention on cover_url / avatar_url | #227 | A10 |
| Pillow sanitize (always-on) + ClamAV scan (opt-in) | #228 | A04 |
| Ownership audit on PATCH/DELETE user-books | #229 | A01 |
| Turnstile required by default | #230 | A05 |
| Daily refresh token cleanup job | #231 | A07 |
| Security test expansion | #232 | — |
| CI pipeline: Bandit, pip-audit, ZAP | #233 | A06/A09 |

## Current status
- [x] #226 — Input length limits (landed)
- [ ] #227 — SSRF prevention
- [ ] #228 — File sanitization / ClamAV
- [ ] #229 — Ownership audit
- [ ] #230 — Turnstile required
- [ ] #231 — Token cleanup
- [ ] #232 — Test expansion
- [ ] #233 — CI pipeline

## Test plan
- [ ] `pytest tests/security/ -m security -v` — all pass
- [ ] `pytest tests/ --cov=app` — coverage ≥ 80%
- [ ] `bandit -r app/ -ll` — no new findings
- [ ] Manual smoke: oversized payload → 422, private IP cover_url → 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)