### PR TITLE
feat(my-books): bento list layout + fix header/hero title overlap

### DIFF
--- a/frontend/app/(auth)/login.tsx
+++ b/frontend/app/(auth)/login.tsx
@@ -55,6 +55,7 @@ export default function LoginScreen() {
       <Image
         source={require('../../assets/logo.png')}
         style={styles.logo}
+        resizeMode="contain"
         accessibilityLabel="BookshelfAI"
         accessibilityRole="image"
       />
@@ -132,9 +133,9 @@ const styles = StyleSheet.create({
     paddingHorizontal: 32,
   },
   logo: {
-    width: 96,
-    height: 96,
-    borderRadius: 20,
+    width: 120,
+    height: 120,
+    borderRadius: 24,
     marginBottom: 24,
   },
   title: {

--- a/frontend/app/(tabs)/my-books.tsx
+++ b/frontend/app/(tabs)/my-books.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
 import {
   Alert,
-  Dimensions,
   FlatList,
   Image,
   Modal,
@@ -15,6 +14,7 @@ import {
 } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
 import { useFocusEffect } from 'expo-router';
+import { useHeaderHeight } from '@react-navigation/elements';
 import { useTranslation } from 'react-i18next';
 
 import { LoadingSpinner } from '../../components/LoadingSpinner';
@@ -55,37 +55,13 @@ const NEXT_STATUS: Record<string, string> = {
 };
 
 const SCREEN_PADDING = 16;
-const COLUMN_GAP = 12;
-const NUM_COLUMNS = 2;
-
-function cardWidth() {
-  const screenWidth = Dimensions.get('window').width;
-  return (screenWidth - SCREEN_PADDING * 2 - COLUMN_GAP * (NUM_COLUMNS - 1)) / NUM_COLUMNS;
-}
-
-function statusBadgeColors(
-  status: string,
-  theme: ReturnType<typeof import('../../hooks/useTheme').useTheme>['theme']
-) {
-  if (status === 'reading')
-    return { bg: theme.colors.primary, text: theme.colors.onPrimary, overlay: true };
-  if (status === 'read')
-    return {
-      bg: theme.colors.secondaryContainer,
-      text: theme.colors.onSecondaryContainer,
-      overlay: true,
-    };
-  // wishlisted / purchased — subtle chip below author
-  return {
-    bg: theme.colors.surfaceContainerHigh,
-    text: theme.colors.onSurfaceVariant,
-    overlay: false,
-  };
-}
 
 export default function MyBooksScreen() {
   const { theme } = useTheme();
   const { t } = useTranslation('my-books');
+  const headerHeight = useHeaderHeight();
+  // Transparent header only in dark mode — push content below the floating header.
+  const topPad = theme.isDark ? headerHeight : 0;
   // Gold tertiary in dark mode, primary in light mode — active/CTA accent.
   const activeColor = theme.isDark ? theme.colors.tertiary : theme.colors.primary;
   const onActiveColor = theme.isDark ? theme.colors.onTertiary : theme.colors.onPrimary;
@@ -163,9 +139,6 @@ export default function MyBooksScreen() {
     );
   }, [books, query]);
 
-  const cw = cardWidth();
-  const coverHeight = cw * 1.5;
-
   if (loading) {
     return (
       <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
@@ -174,10 +147,49 @@ export default function MyBooksScreen() {
     );
   }
 
+  const listHeader = (
+    <View style={styles.listHeader}>
+      <Text
+        style={[
+          styles.heroTitle,
+          {
+            color: theme.colors.text,
+            fontFamily: theme.typography.fontFamilyHeadline,
+            fontSize: theme.typography.fontSizeH1,
+          },
+        ]}
+      >
+        {t('sectionTitle')}
+      </Text>
+      <Text
+        style={[
+          styles.heroSubtitle,
+          { color: theme.colors.textSecondary, fontSize: theme.typography.fontSizeSM },
+        ]}
+      >
+        {t('heroSubtitle')}
+      </Text>
+
+      {/* Archive summary card */}
+      <View style={[styles.summaryCard, { backgroundColor: theme.colors.surfaceContainerHigh }]}>
+        <View style={[styles.summaryAccent, { backgroundColor: activeColor }]} />
+        <Text style={[styles.summaryCount, { color: theme.colors.text }]}>{books.length}</Text>
+        <Text
+          style={[
+            styles.summaryLabel,
+            { color: theme.colors.textSecondary, fontSize: theme.typography.fontSizeSM },
+          ]}
+        >
+          {t('archiveSummary')}
+        </Text>
+      </View>
+    </View>
+  );
+
   return (
     <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
-      {/* Search bar */}
-      <View style={styles.searchRow}>
+      {/* Search bar — paddingTop offsets for transparent floating header in dark mode */}
+      <View style={[styles.searchRow, { paddingTop: 12 + topPad }]}>
         <View
           style={[styles.searchWrap, { backgroundColor: theme.colors.surfaceContainerHighest }]}
         >
@@ -238,29 +250,7 @@ export default function MyBooksScreen() {
         </View>
       </ScrollView>
 
-      {/* Section header */}
-      {books.length > 0 && (
-        <View style={styles.sectionHeader}>
-          <Text
-            style={[
-              styles.sectionTitle,
-              { color: theme.colors.onSurface, fontFamily: theme.typography.fontFamilyHeadline },
-            ]}
-          >
-            {t('sectionTitle')}
-          </Text>
-          <Text
-            style={[
-              styles.sectionSubtitle,
-              { color: theme.colors.secondary, fontSize: theme.typography.fontSizeSM },
-            ]}
-          >
-            {t('bookCount', { count: books.length })}
-          </Text>
-        </View>
-      )}
-
-      {/* Book grid */}
+      {/* Bento list */}
       {filteredBooks.length === 0 ? (
         <View style={styles.emptyContainer}>
           <Text
@@ -276,9 +266,8 @@ export default function MyBooksScreen() {
         <FlatList
           data={filteredBooks}
           keyExtractor={(item) => item.id}
-          numColumns={NUM_COLUMNS}
-          columnWrapperStyle={styles.row}
-          contentContainerStyle={styles.gridContent}
+          contentContainerStyle={styles.list}
+          ListHeaderComponent={listHeader}
           refreshControl={
             <RefreshControl
               refreshing={refreshing}
@@ -290,10 +279,16 @@ export default function MyBooksScreen() {
             />
           }
           renderItem={({ item }) => {
-            const badge = statusBadgeColors(item.status, theme);
+            const nextStatus = NEXT_STATUS[item.status];
             return (
               <Pressable
-                style={[styles.card, { width: cw }]}
+                style={[
+                  styles.card,
+                  {
+                    backgroundColor: theme.colors.surfaceContainerLow,
+                    borderLeftColor: activeColor,
+                  },
+                ]}
                 onPress={() => setSelected(item)}
                 accessibilityRole="button"
                 accessibilityLabel={t('bookCardA11y', {
@@ -303,76 +298,119 @@ export default function MyBooksScreen() {
                 accessibilityHint={t('bookCardHint')}
               >
                 {/* Cover */}
-                <View
-                  style={[
-                    styles.coverWrap,
-                    {
-                      width: cw,
-                      height: coverHeight,
-                      backgroundColor: theme.colors.surfaceContainerHighest,
-                    },
-                  ]}
-                >
-                  {item.book.cover_url ? (
-                    <Image
-                      source={{ uri: item.book.cover_url }}
-                      style={StyleSheet.absoluteFill}
-                      resizeMode="cover"
-                      accessibilityLabel={t('coverAlt', { ns: 'common', title: item.book.title })}
-                    />
-                  ) : (
-                    <View
-                      style={[StyleSheet.absoluteFill, { backgroundColor: theme.colors.border }]}
-                      accessibilityLabel={t('noCoverAvailable', { ns: 'common' })}
-                    />
-                  )}
-                  {badge.overlay && (
-                    <View style={[styles.badgeOverlay, { backgroundColor: badge.bg }]}>
-                      <Text style={[styles.badgeText, { color: badge.text }]}>
-                        {t(`status.${item.status}`, item.status)}
-                      </Text>
-                    </View>
-                  )}
-                </View>
-
-                {/* Title + author */}
-                <Text
-                  style={[
-                    styles.cardTitle,
-                    {
-                      color: theme.colors.onSurface,
-                      fontFamily: theme.typography.fontFamilyHeadline,
-                      fontSize: theme.typography.fontSizeBase,
-                    },
-                  ]}
-                  numberOfLines={2}
-                >
-                  {item.book.title}
-                </Text>
-                <Text
-                  style={[
-                    styles.cardAuthor,
-                    { color: theme.colors.secondary, fontSize: theme.typography.fontSizeXS },
-                  ]}
-                  numberOfLines={1}
-                >
-                  {item.book.author}
-                </Text>
-                {/* Status chip for non-overlay statuses */}
-                {!badge.overlay && (
-                  <View style={[styles.statusChip, { backgroundColor: badge.bg }]}>
-                    <Text style={[styles.badgeText, { color: badge.text }]}>
-                      {t(`status.${item.status}`, item.status)}
-                    </Text>
-                  </View>
+                {item.book.cover_url ? (
+                  <Image
+                    source={{ uri: item.book.cover_url }}
+                    style={styles.cover}
+                    resizeMode="cover"
+                    accessibilityLabel={t('coverAlt', { ns: 'common', title: item.book.title })}
+                  />
+                ) : (
+                  <View
+                    style={[
+                      styles.cover,
+                      styles.coverPlaceholder,
+                      { backgroundColor: theme.colors.border },
+                    ]}
+                    accessibilityLabel={t('noCoverAvailable', { ns: 'common' })}
+                  />
                 )}
+
+                {/* Content */}
+                <View style={styles.content}>
+                  <Text
+                    style={[
+                      styles.categoryLabel,
+                      { color: activeColor, fontSize: theme.typography.fontSizeXS },
+                    ]}
+                  >
+                    {t(`status.${item.status}`)}
+                  </Text>
+
+                  <Text
+                    style={[
+                      styles.bookTitle,
+                      { color: theme.colors.text, fontSize: theme.typography.fontSizeBase },
+                    ]}
+                    numberOfLines={2}
+                  >
+                    {item.book.title}
+                  </Text>
+
+                  <Text
+                    style={[
+                      styles.bookAuthor,
+                      { color: theme.colors.textSecondary, fontSize: theme.typography.fontSizeSM },
+                    ]}
+                    numberOfLines={1}
+                  >
+                    {item.book.author}
+                  </Text>
+
+                  {item.edition?.publish_year ? (
+                    <Text
+                      style={[
+                        styles.bookYear,
+                        {
+                          color: theme.colors.textSecondary,
+                          fontSize: theme.typography.fontSizeXS,
+                        },
+                      ]}
+                    >
+                      {item.edition.publish_year}
+                    </Text>
+                  ) : null}
+
+                  <View style={styles.actions}>
+                    {nextStatus && (
+                      <Pressable
+                        style={[styles.actionButton, { backgroundColor: activeColor }]}
+                        onPress={() => handleAdvanceStatus(item)}
+                        accessibilityRole="button"
+                        accessibilityLabel={t('markAsA11y', {
+                          status: t(`status.${nextStatus}`),
+                        })}
+                      >
+                        <Text
+                          style={[
+                            styles.actionText,
+                            { fontSize: theme.typography.fontSizeXS, color: onActiveColor },
+                          ]}
+                        >
+                          {t('markAs', { status: t(`status.${nextStatus}`) })}
+                        </Text>
+                      </Pressable>
+                    )}
+                    <Pressable
+                      style={[
+                        styles.actionButton,
+                        { backgroundColor: theme.colors.secondaryContainer },
+                      ]}
+                      onPress={() => handleRemove(item)}
+                      accessibilityRole="button"
+                      accessibilityLabel={t('removeBookA11y', { title: item.book.title })}
+                    >
+                      <Text
+                        style={[
+                          styles.actionText,
+                          {
+                            color: theme.colors.onSecondaryContainer,
+                            fontSize: theme.typography.fontSizeXS,
+                          },
+                        ]}
+                      >
+                        {t('removeFromList')}
+                      </Text>
+                    </Pressable>
+                  </View>
+                </View>
               </Pressable>
             );
           }}
         />
       )}
 
-      {/* Detail sheet */}
+      {/* Detail sheet — full book info, advance status, remove */}
       <Modal
         visible={!!selected}
         animationType="slide"
@@ -492,7 +530,7 @@ const styles = StyleSheet.create({
   container: { flex: 1 },
 
   // Search
-  searchRow: { paddingHorizontal: SCREEN_PADDING, paddingTop: 12, paddingBottom: 4 },
+  searchRow: { paddingHorizontal: SCREEN_PADDING, paddingBottom: 4 },
   searchWrap: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -520,70 +558,62 @@ const styles = StyleSheet.create({
   },
   tabText: { fontWeight: '600' },
 
-  // Section header
-  sectionHeader: {
-    paddingHorizontal: SCREEN_PADDING,
-    paddingTop: 16,
-    paddingBottom: 8,
-  },
-  sectionTitle: {
-    fontSize: 32,
+  // Bento list
+  list: { paddingHorizontal: SCREEN_PADDING, paddingBottom: 32, gap: 12 },
+
+  // Hero + summary
+  listHeader: { marginBottom: 8, gap: 6 },
+  heroTitle: {
     fontWeight: '700',
+    lineHeight: 48,
     letterSpacing: -0.5,
-    marginBottom: 2,
   },
-  sectionSubtitle: { fontWeight: '500', opacity: 0.8 },
-
-  // Grid
-  gridContent: {
-    paddingHorizontal: SCREEN_PADDING,
-    paddingBottom: 32,
-  },
-  row: {
-    gap: COLUMN_GAP,
-    marginBottom: 24,
-  },
-  card: { flexDirection: 'column' },
-
-  // Book card cover
-  coverWrap: {
+  heroSubtitle: { lineHeight: 20, marginBottom: 4 },
+  summaryCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
     borderRadius: 12,
     overflow: 'hidden',
-    marginBottom: 10,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    gap: 12,
+    marginTop: 4,
   },
-  badgeOverlay: {
-    position: 'absolute',
-    top: 10,
-    right: 10,
-    paddingHorizontal: 8,
-    paddingVertical: 4,
-    borderRadius: 6,
+  summaryAccent: { width: 3, height: 32, borderRadius: 2 },
+  summaryCount: { fontSize: 28, fontWeight: '700', lineHeight: 32 },
+  summaryLabel: { flex: 1, lineHeight: 18 },
+
+  // Bento card
+  card: {
+    flexDirection: 'row',
+    borderRadius: 12,
+    overflow: 'hidden',
+    minHeight: 120,
+    borderLeftWidth: 4,
   },
-  badgeText: {
-    fontSize: 10,
-    fontWeight: '700',
+  cover: { width: 110, alignSelf: 'stretch' },
+  coverPlaceholder: { opacity: 0.4 },
+  content: { flex: 1, padding: 12, gap: 4 },
+  categoryLabel: {
     textTransform: 'uppercase',
-    letterSpacing: 0.6,
-  },
-  cardTitle: {
+    letterSpacing: 1,
     fontWeight: '700',
-    lineHeight: 22,
     marginBottom: 2,
   },
-  cardAuthor: {
-    fontWeight: '500',
-    letterSpacing: 0.8,
-    textTransform: 'uppercase',
-  },
-  statusChip: {
-    alignSelf: 'flex-start',
-    marginTop: 6,
-    paddingHorizontal: 8,
-    paddingVertical: 3,
+  bookTitle: { fontWeight: '600', lineHeight: 22 },
+  bookAuthor: { lineHeight: 18 },
+  bookYear: { lineHeight: 16 },
+  actions: { flexDirection: 'row', gap: 8, marginTop: 8, flexWrap: 'wrap' },
+  actionButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
     borderRadius: 6,
+    minHeight: 32,
+    justifyContent: 'center',
   },
+  actionText: { fontWeight: '600' },
 
-  // Empty / loading
+  // Empty
   emptyContainer: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32 },
   emptyText: { textAlign: 'center' },
 

--- a/frontend/app/(tabs)/wishlist.tsx
+++ b/frontend/app/(tabs)/wishlist.tsx
@@ -10,6 +10,7 @@ import {
   View,
 } from 'react-native';
 import { useFocusEffect } from 'expo-router';
+import { useHeaderHeight } from '@react-navigation/elements';
 import { useTranslation } from 'react-i18next';
 
 import { LoadingSpinner } from '../../components/LoadingSpinner';
@@ -33,6 +34,9 @@ interface UserBook {
 export default function WishlistScreen() {
   const { theme } = useTheme();
   const { t } = useTranslation('wishlist');
+  const headerHeight = useHeaderHeight();
+  // Transparent header only in dark mode — push list content below it.
+  const topPad = theme.isDark ? headerHeight : 0;
   // Gold tertiary in dark mode, primary in light mode — active/CTA accent.
   const activeColor = theme.isDark ? theme.colors.tertiary : theme.colors.primary;
   const onActiveColor = theme.isDark ? theme.colors.onTertiary : theme.colors.onPrimary;
@@ -155,7 +159,7 @@ export default function WishlistScreen() {
       <FlatList
         data={books}
         keyExtractor={(item) => item.id}
-        contentContainerStyle={styles.list}
+        contentContainerStyle={[styles.list, { paddingTop: topPad }]}
         ListHeaderComponent={listHeader}
         refreshControl={
           <RefreshControl

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -41,6 +41,7 @@ function HeaderLogo() {
       <Image
         source={require('../assets/icon.png')}
         style={headerStyles.logo}
+        resizeMode="contain"
         accessibilityLabel="BookshelfAI"
         accessibilityRole="image"
       />
@@ -73,7 +74,7 @@ function InnerStack() {
 
 const headerStyles = StyleSheet.create({
   row: { flexDirection: 'row', alignItems: 'center', gap: 8 },
-  logo: { width: 28, height: 28, borderRadius: 6 },
+  logo: { width: 40, height: 40, borderRadius: 8 },
   wordmark: {
     fontSize: 20,
     fontFamily: 'NotoSerif_700Bold',

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -1,3 +1,8 @@
+// useHeaderHeight throws when rendered outside a navigator; return 0 in tests.
+jest.mock('@react-navigation/elements', () => ({
+  useHeaderHeight: () => 0,
+}));
+
 // Initialize i18n with English resources before every test.
 // en translations are bundled as static imports and available synchronously;
 // components calling useTranslation() will get the correct English strings.

--- a/frontend/src/i18n/locales/ar/my-books.json
+++ b/frontend/src/i18n/locales/ar/my-books.json
@@ -29,5 +29,7 @@
   "searchPlaceholder": "__NEEDS_TRANSLATION__",
   "searchA11y": "__NEEDS_TRANSLATION__",
   "sectionTitle": "__NEEDS_TRANSLATION__",
-  "bookCount": "__NEEDS_TRANSLATION__"
+  "bookCount": "__NEEDS_TRANSLATION__",
+  "heroSubtitle": "حياتك القرائية في مكان واحد",
+  "archiveSummary": "كتب مسجلة"
 }

--- a/frontend/src/i18n/locales/de/my-books.json
+++ b/frontend/src/i18n/locales/de/my-books.json
@@ -29,5 +29,7 @@
   "searchPlaceholder": "__NEEDS_TRANSLATION__",
   "searchA11y": "__NEEDS_TRANSLATION__",
   "sectionTitle": "__NEEDS_TRANSLATION__",
-  "bookCount": "__NEEDS_TRANSLATION__"
+  "bookCount": "__NEEDS_TRANSLATION__",
+  "heroSubtitle": "Dein Leserleben auf einen Blick",
+  "archiveSummary": "Bücher erfasst"
 }

--- a/frontend/src/i18n/locales/en/my-books.json
+++ b/frontend/src/i18n/locales/en/my-books.json
@@ -29,5 +29,7 @@
   "searchPlaceholder": "Search your library...",
   "searchA11y": "Search your library",
   "sectionTitle": "My Library",
-  "bookCount": "{{count}} volumes in your collection."
+  "bookCount": "{{count}} volumes in your collection.",
+  "heroSubtitle": "Your reading life in one place",
+  "archiveSummary": "books tracked"
 }

--- a/frontend/src/i18n/locales/es/my-books.json
+++ b/frontend/src/i18n/locales/es/my-books.json
@@ -29,5 +29,7 @@
   "searchPlaceholder": "__NEEDS_TRANSLATION__",
   "searchA11y": "__NEEDS_TRANSLATION__",
   "sectionTitle": "__NEEDS_TRANSLATION__",
-  "bookCount": "__NEEDS_TRANSLATION__"
+  "bookCount": "__NEEDS_TRANSLATION__",
+  "heroSubtitle": "Tu vida lectora en un lugar",
+  "archiveSummary": "libros registrados"
 }

--- a/frontend/src/i18n/locales/fr-CA/my-books.json
+++ b/frontend/src/i18n/locales/fr-CA/my-books.json
@@ -29,5 +29,7 @@
   "searchPlaceholder": "__NEEDS_TRANSLATION__",
   "searchA11y": "__NEEDS_TRANSLATION__",
   "sectionTitle": "__NEEDS_TRANSLATION__",
-  "bookCount": "__NEEDS_TRANSLATION__"
+  "bookCount": "__NEEDS_TRANSLATION__",
+  "heroSubtitle": "Toute ta vie de lecture ici",
+  "archiveSummary": "livres suivis"
 }

--- a/frontend/src/i18n/locales/he/my-books.json
+++ b/frontend/src/i18n/locales/he/my-books.json
@@ -29,5 +29,7 @@
   "searchPlaceholder": "__NEEDS_TRANSLATION__",
   "searchA11y": "__NEEDS_TRANSLATION__",
   "sectionTitle": "__NEEDS_TRANSLATION__",
-  "bookCount": "__NEEDS_TRANSLATION__"
+  "bookCount": "__NEEDS_TRANSLATION__",
+  "heroSubtitle": "חיי הקריאה שלך במקום אחד",
+  "archiveSummary": "ספרים במעקב"
 }

--- a/frontend/src/i18n/locales/hi/my-books.json
+++ b/frontend/src/i18n/locales/hi/my-books.json
@@ -29,5 +29,7 @@
   "searchPlaceholder": "__NEEDS_TRANSLATION__",
   "searchA11y": "__NEEDS_TRANSLATION__",
   "sectionTitle": "__NEEDS_TRANSLATION__",
-  "bookCount": "__NEEDS_TRANSLATION__"
+  "bookCount": "__NEEDS_TRANSLATION__",
+  "heroSubtitle": "आपकी पढ़ाई की दुनिया एक जगह",
+  "archiveSummary": "किताबें दर्ज"
 }

--- a/frontend/src/i18n/locales/ja/my-books.json
+++ b/frontend/src/i18n/locales/ja/my-books.json
@@ -29,5 +29,7 @@
   "searchPlaceholder": "__NEEDS_TRANSLATION__",
   "searchA11y": "__NEEDS_TRANSLATION__",
   "sectionTitle": "__NEEDS_TRANSLATION__",
-  "bookCount": "__NEEDS_TRANSLATION__"
+  "bookCount": "__NEEDS_TRANSLATION__",
+  "heroSubtitle": "あなたの読書生活を一箇所で",
+  "archiveSummary": "冊を記録中"
 }

--- a/frontend/src/i18n/locales/ko/my-books.json
+++ b/frontend/src/i18n/locales/ko/my-books.json
@@ -29,5 +29,7 @@
   "searchPlaceholder": "__NEEDS_TRANSLATION__",
   "searchA11y": "__NEEDS_TRANSLATION__",
   "sectionTitle": "__NEEDS_TRANSLATION__",
-  "bookCount": "__NEEDS_TRANSLATION__"
+  "bookCount": "__NEEDS_TRANSLATION__",
+  "heroSubtitle": "나의 독서 생활 한눈에",
+  "archiveSummary": "권 등록됨"
 }

--- a/frontend/src/i18n/locales/nl/my-books.json
+++ b/frontend/src/i18n/locales/nl/my-books.json
@@ -29,5 +29,7 @@
   "searchPlaceholder": "__NEEDS_TRANSLATION__",
   "searchA11y": "__NEEDS_TRANSLATION__",
   "sectionTitle": "__NEEDS_TRANSLATION__",
-  "bookCount": "__NEEDS_TRANSLATION__"
+  "bookCount": "__NEEDS_TRANSLATION__",
+  "heroSubtitle": "Jouw leesleven op één plek",
+  "archiveSummary": "boeken bijgehouden"
 }

--- a/frontend/src/i18n/locales/pt/my-books.json
+++ b/frontend/src/i18n/locales/pt/my-books.json
@@ -29,5 +29,7 @@
   "searchPlaceholder": "__NEEDS_TRANSLATION__",
   "searchA11y": "__NEEDS_TRANSLATION__",
   "sectionTitle": "__NEEDS_TRANSLATION__",
-  "bookCount": "__NEEDS_TRANSLATION__"
+  "bookCount": "__NEEDS_TRANSLATION__",
+  "heroSubtitle": "Sua vida leitora em um lugar",
+  "archiveSummary": "livros registrados"
 }

--- a/frontend/src/i18n/locales/ru/my-books.json
+++ b/frontend/src/i18n/locales/ru/my-books.json
@@ -29,5 +29,7 @@
   "searchPlaceholder": "__NEEDS_TRANSLATION__",
   "searchA11y": "__NEEDS_TRANSLATION__",
   "sectionTitle": "__NEEDS_TRANSLATION__",
-  "bookCount": "__NEEDS_TRANSLATION__"
+  "bookCount": "__NEEDS_TRANSLATION__",
+  "heroSubtitle": "Вся ваша читательская жизнь здесь",
+  "archiveSummary": "книг отслеживается"
 }

--- a/frontend/src/i18n/locales/zh/my-books.json
+++ b/frontend/src/i18n/locales/zh/my-books.json
@@ -29,5 +29,7 @@
   "searchPlaceholder": "__NEEDS_TRANSLATION__",
   "searchA11y": "__NEEDS_TRANSLATION__",
   "sectionTitle": "__NEEDS_TRANSLATION__",
-  "bookCount": "__NEEDS_TRANSLATION__"
+  "bookCount": "__NEEDS_TRANSLATION__",
+  "heroSubtitle": "您的阅读生活，尽在一处",
+  "archiveSummary": "本书已记录"
 }


### PR DESCRIPTION
## Summary
- Redesigns My Books from a 2-column cover grid to a single-column bento list matching the Wishlist screen (#252)
- Fixes the header/hero title overlap visible in dark mode on both Wishlist and My Books (#253)

## My Books redesign (#252)
- **Hero header**: serif H1 "My Library" title + subtitle + archive summary card with item count and gold accent bar
- **Bento cards**: 110px cover image · 4px gold/primary left-border accent · status category label (UPPERCASE) · title · author · year
- **Inline actions** directly on each card:
  - `wishlisted` → Mark as Purchased + Remove
  - `purchased` → Mark as Reading + Remove
  - `reading` → Mark as Read + Remove
  - `read` → Remove only
- Search bar and filter tabs (All / Wishlist / Purchased / Reading / Read) unchanged
- Detail modal (tap card) still shows full book info, description, pages
- Removed: 2-col grid, `Dimensions`, `cardWidth()`, `statusBadgeColors`, badge overlays
- New i18n keys `heroSubtitle` + `archiveSummary` added to all 13 locales

## Header overlap fix (#253)
- `useHeaderHeight()` from `@react-navigation/elements` — returns the floating header's height
- `topPad = theme.isDark ? headerHeight : 0` — only compensates when header is transparent
- **My Books**: `paddingTop: 12 + topPad` on the search row — pushes search bar, tabs, and list below the header
- **Wishlist**: `paddingTop: topPad` added to `FlatList` `contentContainerStyle`
- **jest.setup.ts**: global mock `useHeaderHeight → 0` so tests pass outside a navigator context

## Test plan
- [ ] 215 Jest tests pass
- [ ] No new TypeScript errors in source files
- [ ] Prettier clean
- [ ] Visual dark mode: hero title no longer overlaps "BookshelfAI" wordmark on Wishlist or My Books
- [ ] Visual: My Books shows bento cards matching Wishlist style
- [ ] Filter tabs still correctly filter the list
- [ ] Inline "Mark as X" and "Remove" buttons work with optimistic updates + rollback on error
- [ ] Detail modal still opens on card tap

Closes #252, closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)