### PR TITLE
feat: sync iOS and Android native versions on release

### DIFF
--- a/.github/workflows/sync-native-versions.yml
+++ b/.github/workflows/sync-native-versions.yml
@@ -1,0 +1,93 @@
+name: Sync Native Versions
+
+# Fires when release-please publishes a GitHub Release.
+# Reads the new semver from frontend/package.json, increments the build
+# number (versionCode / buildNumber / CURRENT_PROJECT_VERSION), and
+# patches the three native version files so all platforms stay in sync.
+#
+# Commit uses "chore:" prefix — release-please ignores it (no bump).
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  sync-native-versions:
+    name: Sync iOS & Android versions
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          # Use default GITHUB_TOKEN — contents:write is enough for a direct push
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve new semver and build number
+        id: ver
+        run: |
+          SEMVER=$(jq -r '.version' frontend/package.json)
+          CURRENT_BUILD=$(jq -r '.expo.android.versionCode' frontend/app.json)
+          BUILD=$(( CURRENT_BUILD + 1 ))
+          echo "semver=$SEMVER"   >> "$GITHUB_OUTPUT"
+          echo "build=$BUILD"     >> "$GITHUB_OUTPUT"
+
+      - name: Patch frontend/app.json
+        env:
+          SEMVER: ${{ steps.ver.outputs.semver }}
+          BUILD:  ${{ steps.ver.outputs.build }}
+        run: |
+          python3 - << 'PYEOF'
+          import json, os
+          path = 'frontend/app.json'
+          with open(path) as f:
+              data = json.load(f)
+          data['expo']['version']                  = os.environ['SEMVER']
+          data['expo']['ios']['buildNumber']        = os.environ['BUILD']
+          data['expo']['android']['versionCode']    = int(os.environ['BUILD'])
+          with open(path, 'w') as f:
+              json.dump(data, f, indent=2)
+              f.write('\n')
+          PYEOF
+
+      - name: Patch frontend/android/app/build.gradle
+        env:
+          SEMVER: ${{ steps.ver.outputs.semver }}
+          BUILD:  ${{ steps.ver.outputs.build }}
+        run: |
+          sed -i \
+            -e "s/versionCode [0-9]\+/versionCode $BUILD/" \
+            -e "s/versionName \"[^\"]*\"/versionName \"$SEMVER\"/" \
+            frontend/android/app/build.gradle
+
+      - name: Patch frontend/ios/BookShelfAI.xcodeproj/project.pbxproj
+        env:
+          SEMVER: ${{ steps.ver.outputs.semver }}
+          BUILD:  ${{ steps.ver.outputs.build }}
+        run: |
+          sed -i \
+            -e "s/CURRENT_PROJECT_VERSION = [^;]*;/CURRENT_PROJECT_VERSION = $BUILD;/g" \
+            -e "s/MARKETING_VERSION = [^;]*;/MARKETING_VERSION = $SEMVER;/g" \
+            frontend/ios/BookShelfAI.xcodeproj/project.pbxproj
+
+      - name: Commit and push
+        env:
+          SEMVER: ${{ steps.ver.outputs.semver }}
+          BUILD:  ${{ steps.ver.outputs.build }}
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add \
+            frontend/app.json \
+            frontend/android/app/build.gradle \
+            "frontend/ios/BookShelfAI.xcodeproj/project.pbxproj"
+          # Only commit if anything actually changed
+          if git diff --cached --quiet; then
+            echo "No version changes to commit."
+          else
+            git commit -m "chore: sync native versions to v$SEMVER (build $BUILD)"
+            git push
+          fi

--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -95,7 +95,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName "1.0.0"
+        versionName "0.1.0"
 
         buildConfigField "String", "REACT_NATIVE_RELEASE_LEVEL", "\"${findProperty('reactNativeReleaseLevel') ?: 'stable'}\""
     }

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "BookShelfAI",
     "slug": "bookshelf",
-    "version": "1.0.0",
+    "version": "0.1.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",

--- a/frontend/ios/BookShelfAI.xcodeproj/project.pbxproj
+++ b/frontend/ios/BookShelfAI.xcodeproj/project.pbxproj
@@ -371,7 +371,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 0.1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -402,7 +402,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 0.1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/sync-native-versions.yml` — fires on every `release: published` event (triggered by release-please) and patches all native version fields to match the new semver + auto-incremented build number
- Aligns the currently-hardcoded values in `app.json`, `build.gradle`, and `project.pbxproj` to `0.1.0` / build `1` to match `package.json` (they were stuck at `1.0.0`)

**Fields updated per release:**

| File | Fields |
|------|--------|
| `frontend/app.json` | `expo.version`, `ios.buildNumber`, `android.versionCode` |
| `frontend/android/app/build.gradle` | `versionName`, `versionCode` |
| `frontend/ios/BookShelfAI.xcodeproj/project.pbxproj` | `MARKETING_VERSION` ×2, `CURRENT_PROJECT_VERSION` ×2 |

**Build number strategy:** reads current `android.versionCode` from `app.json` and increments by 1. Monotonically increasing, deterministic, and independent of GitHub run numbers.

**release-please safety:** the patch commit uses `chore:` prefix — release-please ignores non-releaseable commits, so no version bump loop.

Closes #261

## Test plan

- [ ] Merge this PR to `dev`, then to `main`
- [ ] Trigger a `feat:` PR to `main` → release-please opens a Release PR → merge it → release-please publishes a GitHub Release
- [ ] Verify `sync-native-versions` job runs and all four files are updated with the new semver and incremented build number
- [ ] Confirm no second Release PR is opened after the patch commit lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)