### PR TITLE
ci: wire called-feedback-token-lint as tier 1 job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,11 @@ jobs:
     uses: wcmchenry3-stack/.github/.github/workflows/called-openai-policy.yml@main
     secrets: inherit
 
+  feedback-token-lint:
+    needs: [lint-python, lint-frontend, secret-scan]
+    uses: wcmchenry3-stack/.github/.github/workflows/called-feedback-token-lint.yml@main
+    secrets: inherit
+
   test-python:
     needs: [lint-python, lint-frontend, secret-scan]
     uses: wcmchenry3-stack/.github/.github/workflows/called-test-python.yml@main


### PR DESCRIPTION
## Summary
Adds \`called-feedback-token-lint\` as a tier 1 job in \`.github/workflows/ci.yml\`. The reusable workflow validates that \`frontend/feedback-theme.css\` defines every required \`--feedback-*\` token from the org schema (\`schemas/feedback-widget-tokens.schema.json\` in dot-github).

book_app's feedback widget (#111) is already shipped but does not include a separate \`feedback-theme.css\` file (uses inline styles). The workflow skips gracefully when the theme file is absent, so this wiring has zero impact until a theme file is added. Enforcement mode is \`advisory\` per org default in \`policy-enforcement.yml\`.

Closes wcmchenry3-stack/.github#119

## Test plan
- [ ] CI passes — \`feedback-token-lint\` runs in tier 1 and skips with a notice (theme file absent)
- [ ] Tier ordering preserved (job runs after tier 0, in parallel with other tier 1 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)