### PR TITLE
fix(ci): fix zap-scan and expo-sdk-upgrade-tracker workflow file issues

### DIFF
--- a/.github/workflows/expo-sdk-upgrade-tracker.yml
+++ b/.github/workflows/expo-sdk-upgrade-tracker.yml
@@ -117,59 +117,58 @@ jobs:
 
           if [ "$EXIT_CODE" = "0" ]; then
             TITLE="Expo SDK upgrade ready: $CURRENT → $LATEST"
-            BODY="$(cat <<EOBODY
-## All blockers cleared — upgrade is ready
-
-Every installed package is compatible with Expo SDK **$LATEST**.
-
-| | |
-|---|---|
-| Current | \`$CURRENT\` |
-| Target | \`$LATEST\` |
-
-### Steps to upgrade
-1. In \`frontend/package.json\` set \`"expo": "^$LATEST"\`
-2. Run \`npx expo install --fix\` — this re-pins all managed dependencies to the new SDK range
-3. Run \`npm install\` and commit the updated \`package-lock.json\`
-4. Run \`expo prebuild --platform android\` and commit any \`android/\` changes
-5. Open a PR targeting \`dev\` — CI will validate everything
-
-_Checked automatically · $DATE_
-EOBODY
-)"
+            # Build body with printf to keep YAML valid (no unindented heredoc body)
+            printf '%s\n' \
+              "## All blockers cleared — upgrade is ready" \
+              "" \
+              "Every installed package is compatible with Expo SDK **${LATEST}**." \
+              "" \
+              "| | |" \
+              "|---|---|" \
+              "| Current | \`${CURRENT}\` |" \
+              "| Target | \`${LATEST}\` |" \
+              "" \
+              "### Steps to upgrade" \
+              "1. In \`frontend/package.json\` set \`\"expo\": \"^${LATEST}\"\`" \
+              "2. Run \`npx expo install --fix\` — this re-pins all managed dependencies to the new SDK range" \
+              "3. Run \`npm install\` and commit the updated \`package-lock.json\`" \
+              "4. Run \`expo prebuild --platform android\` and commit any \`android/\` changes" \
+              "5. Open a PR targeting \`dev\` — CI will validate everything" \
+              "" \
+              "_Checked automatically · ${DATE}_" \
+              > /tmp/issue-body.md
           else
             TITLE="Expo SDK upgrade blocked: $CURRENT → $LATEST"
-            BODY="$(cat <<EOBODY
-## Upgrade to Expo SDK $LATEST is not yet ready
-
-The following packages need new versions before the SDK can be bumped:
-
-\`\`\`
-$BLOCKERS
-\`\`\`
-
-This issue updates automatically every Monday. No action needed until all blockers clear.
-
-| | |
-|---|---|
-| Current | \`$CURRENT\` |
-| Target | \`$LATEST\` |
-
-_Last checked: $DATE_
-EOBODY
-)"
+            printf '%s\n' \
+              "## Upgrade to Expo SDK ${LATEST} is not yet ready" \
+              "" \
+              "The following packages need new versions before the SDK can be bumped:" \
+              "" \
+              "\`\`\`" \
+              "${BLOCKERS}" \
+              "\`\`\`" \
+              "" \
+              "This issue updates automatically every Monday. No action needed until all blockers clear." \
+              "" \
+              "| | |" \
+              "|---|---|" \
+              "| Current | \`${CURRENT}\` |" \
+              "| Target | \`${LATEST}\` |" \
+              "" \
+              "_Last checked: ${DATE}_" \
+              > /tmp/issue-body.md
           fi
 
           if [ -n "$EXISTING" ]; then
             gh issue edit "$EXISTING" \
               --title "$TITLE" \
-              --body "$BODY" \
+              --body-file /tmp/issue-body.md \
               --repo "$REPO"
             echo "Updated issue #$EXISTING"
           else
             gh issue create \
               --title "$TITLE" \
-              --body "$BODY" \
+              --body-file /tmp/issue-body.md \
               --label "$LABEL" \
               --repo "$REPO"
             echo "Created new tracking issue"

--- a/.github/workflows/zap-scan.yml
+++ b/.github/workflows/zap-scan.yml
@@ -10,6 +10,6 @@ jobs:
   zap-scan:
     uses: wcmchenry3-stack/.github/.github/workflows/called-zap-scheduled.yml@main
     with:
-      target-url: ${{ secrets.SITE_URL }}
       artifact-name: 'zap-weekly-bookshelf'
-    secrets: inherit
+    secrets:
+      target-url-secret: ${{ secrets.SITE_URL }}


### PR DESCRIPTION
## Summary

- **`zap-scan.yml`** — remove `${{ secrets.SITE_URL }}` from the `with:` block; pass it as `target-url-secret` in `secrets:` instead
- **`expo-sdk-upgrade-tracker.yml`** — replace unindented heredoc bodies with `printf '%s\n'` + `--body-file`; bump `actions/setup-node` from v4 → v6

## Why both files showed "workflow file issue" on every push

**`zap-scan.yml`**: GitHub Actions does not allow the `secrets` context in the `with:` block of a reusable workflow call. `${{ secrets.SITE_URL }}` there caused a validation error on every push, making the workflow show its file path as its name (sign of parse failure).

**`expo-sdk-upgrade-tracker.yml`**: YAML literal block scalars (`run: |`) require all content to be indented at the block's indentation level. The heredoc bodies were at column 0, so the YAML parser terminated the block early and tried to parse the heredoc content as YAML keys — causing a `ScannerError: could not find expected ':'` at line 123.

## Dependencies

⚠️ **Merge wcmchenry3-stack/.github#138 first.** That PR adds the `target-url-secret` to `called-zap-scheduled.yml`. If this PR merges before #138, `zap-scan.yml` will fail validation because the called workflow doesn't yet declare `target-url-secret` in its `secrets:` section.

## Test plan
- [ ] After merge, `zap-scan.yml` workflow name shows "ZAP Weekly Scan" (not the file path) in Actions UI
- [ ] After merge, `expo-sdk-upgrade-tracker.yml` workflow name shows "Expo SDK Upgrade Tracker" in Actions UI
- [ ] Neither workflow shows "workflow file issue" on the next push to dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)