### PR TITLE
security: move hardcoded Render service ID to GitHub secret

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,6 @@ jobs:
     uses: wcmchenry3-stack/.github/.github/workflows/called-deploy-render.yml@a973bcce934fef46e22d40123430ad2594d5bada
     with:
       service-name: 'bookshelf-api'
-      service-id: 'srv-d6vkel7fte5s73du7fc0'
+      service-id: ${{ secrets.RENDER_SERVICE_ID }}
       zap-target-url: 'https://bookshelfapi.buffingchi.com'
     secrets: inherit

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,7 +7,7 @@ asyncpg==0.31.0
 aiosqlite==0.22.1
 pydantic==2.13.1
 pydantic-settings==2.13.1
-authlib==1.6.10
+authlib==1.6.11
 PyJWT[cryptography]==2.12.1
 httpx==0.28.1
 slowapi==0.1.9


### PR DESCRIPTION
## Summary
- Replaces the hardcoded Render service ID `srv-d6vkel7fte5s73du7fc0` in `deploy.yml` with `${{ secrets.RENDER_SERVICE_ID }}`
- Resolves [GHSA-pjpv-6vr6-w2v2](https://github.com/wcmchenry3-stack/book_app/security/advisories/GHSA-pjpv-6vr6-w2v2)

## Action Required Before Merging
Add the following secret to this repo's GitHub Actions secrets:
- **Name:** `RENDER_SERVICE_ID`
- **Value:** `srv-d6vkel7fte5s73du7fc0`

Settings → Secrets and variables → Actions → New repository secret

## Test plan
- [ ] Add `RENDER_SERVICE_ID` secret to GitHub Actions secrets
- [ ] Verify deploy workflow runs successfully on next push to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)