### PR TITLE
security: fix auth state desync on token refresh failure

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,7 +7,7 @@ asyncpg==0.31.0
 aiosqlite==0.22.1
 pydantic==2.13.1
 pydantic-settings==2.13.1
-authlib==1.6.10
+authlib==1.6.11
 PyJWT[cryptography]==2.12.1
 httpx==0.28.1
 slowapi==0.1.9

--- a/frontend/__tests__/unit/AuthContext.test.tsx
+++ b/frontend/__tests__/unit/AuthContext.test.tsx
@@ -9,6 +9,7 @@ jest.mock('../../lib/api', () => ({
   api: { post: (...args: unknown[]) => mockPost(...args) },
   ACCESS_TOKEN_KEY: 'bookshelf_access_token',
   REFRESH_TOKEN_KEY: 'bookshelf_refresh_token',
+  setAuthFailureCallback: jest.fn(),
 }));
 
 const mockGetItem = jest.fn();

--- a/frontend/contexts/AuthContext.tsx
+++ b/frontend/contexts/AuthContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useCallback, useEffect, useState } from 'react';
 import { useRouter, useSegments } from 'expo-router';
 
-import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY, api } from '../lib/api';
+import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY, api, setAuthFailureCallback } from '../lib/api';
 import * as storage from '../lib/storage';
 
 interface AuthContextValue {
@@ -33,6 +33,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setIsLoading(false);
     });
   }, []);
+
+  // Register logout as the auth-failure callback so api.ts can signal session expiry
+  useEffect(() => {
+    setAuthFailureCallback(logout);
+  }, [logout]);
 
   // Redirect based on auth state
   useEffect(() => {

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -8,6 +8,13 @@ const BASE_URL = process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:8001';
 export const ACCESS_TOKEN_KEY = 'bookshelf_access_token';
 export const REFRESH_TOKEN_KEY = 'bookshelf_refresh_token';
 
+let onAuthFailure: (() => void) | null = null;
+
+// AuthProvider registers its logout function here on mount to avoid circular imports.
+export function setAuthFailureCallback(cb: () => void) {
+  onAuthFailure = cb;
+}
+
 export const api = axios.create({
   baseURL: BASE_URL,
   headers: { 'Content-Type': 'application/json' },
@@ -47,6 +54,7 @@ api.interceptors.response.use(
         } catch {
           await storage.deleteItem(ACCESS_TOKEN_KEY);
           await storage.deleteItem(REFRESH_TOKEN_KEY);
+          onAuthFailure?.();
         }
       }
     }


### PR DESCRIPTION
## Summary
- Adds a `setAuthFailureCallback` export to `lib/api.ts` so the axios interceptor can signal `AuthContext` when a token refresh fails
- `AuthProvider` registers its `logout` function as that callback on mount
- When refresh fails, tokens are now cleared **and** `isAuthenticated` is set to `false` atomically, redirecting the user to login instead of leaving them on protected screens with no valid tokens
- Resolves [GHSA-hrcw-mhq9-588x](https://github.com/wcmchenry3-stack/BookshelfAI/security/advisories/GHSA-hrcw-mhq9-588x)

## Test plan
- [ ] Simulate a refresh token failure (e.g. revoke the refresh token server-side or mock a 500 on `/auth/refresh`) and verify the app redirects to the login screen
- [ ] Verify normal token refresh still works (access token expiry triggers silent refresh and original request retries)
- [ ] Run `npx jest` — auth context unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)