### PR TITLE
security: harden CI workflows against injection and supply chain attacks

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -105,7 +105,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Run Trivy in filesystem mode
-        uses: aquasecurity/trivy-action@0.35.0 # 57a97c7e7821a5776cebc9bb87c984fa69cba8f1
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -145,7 +145,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: ZAP Full Scan
-        uses: zaproxy/action-full-scan@v0.13.0
+        uses: zaproxy/action-full-scan@3c58388149901b9a03b7718852c5ba889646c27c # v0.13.0
         with:
           target: 'https://bookshelfapi.buffingchi.com'
           rules_file_name: '.zap/rules.tsv'

--- a/.github/workflows/set-sentry-dsn.yml
+++ b/.github/workflows/set-sentry-dsn.yml
@@ -58,11 +58,12 @@ jobs:
           API_ID: ${{ steps.svc.outputs.api_id }}
           DSN: ${{ inputs.sentry_dsn_backend }}
         run: |
+          PAYLOAD=$(jq -n --arg key "SENTRY_DSN" --arg val "$DSN" '[{key: $key, value: $val}]')
           curl -sf -X POST \
             -H "Authorization: Bearer $RENDER_API_KEY" \
             -H "Content-Type: application/json" \
             "https://api.render.com/v1/services/$API_ID/env-vars" \
-            -d "[{\"key\":\"SENTRY_DSN\",\"value\":\"$DSN\"}]"
+            -d "$PAYLOAD"
           echo "SENTRY_DSN set on bookshelf-api"
 
       - name: Set EXPO_PUBLIC_SENTRY_DSN on frontend (POST — does not touch other vars)
@@ -71,9 +72,10 @@ jobs:
           WEB_ID: ${{ steps.svc.outputs.web_id }}
           DSN: ${{ inputs.sentry_dsn_frontend }}
         run: |
+          PAYLOAD=$(jq -n --arg key "EXPO_PUBLIC_SENTRY_DSN" --arg val "$DSN" '[{key: $key, value: $val}]')
           curl -sf -X POST \
             -H "Authorization: Bearer $RENDER_API_KEY" \
             -H "Content-Type: application/json" \
             "https://api.render.com/v1/services/$WEB_ID/env-vars" \
-            -d "[{\"key\":\"EXPO_PUBLIC_SENTRY_DSN\",\"value\":\"$DSN\"}]"
+            -d "$PAYLOAD"
           echo "EXPO_PUBLIC_SENTRY_DSN set on bookshelf-web"

--- a/.github/workflows/sync-native-versions.yml
+++ b/.github/workflows/sync-native-versions.yml
@@ -32,6 +32,14 @@ jobs:
           SEMVER=$(jq -r '.version' frontend/package.json)
           CURRENT_BUILD=$(jq -r '.expo.android.versionCode' frontend/app.json)
           BUILD=$(( CURRENT_BUILD + 1 ))
+          if ! [[ "$SEMVER" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "ERROR: semver '$SEMVER' is not a valid x.y.z version" >&2
+            exit 1
+          fi
+          if ! [[ "$BUILD" =~ ^[0-9]+$ ]]; then
+            echo "ERROR: build '$BUILD' is not a valid integer" >&2
+            exit 1
+          fi
           echo "semver=$SEMVER"   >> "$GITHUB_OUTPUT"
           echo "build=$BUILD"     >> "$GITHUB_OUTPUT"
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,7 +7,7 @@ asyncpg==0.31.0
 aiosqlite==0.22.1
 pydantic==2.13.1
 pydantic-settings==2.13.1
-authlib==1.6.10
+authlib==1.6.11
 PyJWT[cryptography]==2.12.1
 httpx==0.28.1
 slowapi==0.1.9


### PR DESCRIPTION
## Summary
Fixes all 4 CI/CD security advisories in a single PR:

- **GHSA-79cr-mqxq-v2fg** — `set-sentry-dsn.yml`: replace shell-interpolated JSON with `jq` construction, preventing injection of arbitrary Render env vars via `workflow_dispatch` inputs
- **GHSA-9r9c-cfq9-jj8r** — `security.yml`: pin `aquasecurity/trivy-action` to commit SHA `57a97c7e` instead of mutable tag `@0.35.0`
- **GHSA-8287-j75v-qq77** — `security.yml`: pin `zaproxy/action-full-scan` to commit SHA `3c583881` instead of mutable tag `@v0.13.0`
- **GHSA-xjhj-pfv8-g3fw** — `sync-native-versions.yml`: validate `SEMVER` and `BUILD` match expected formats before passing to `sed` commands

## Test plan
- [ ] Trigger `set-sentry-dsn` workflow manually with a valid DSN — verify env var is set correctly on Render
- [ ] Verify `sca-trivy` job passes in CI (SHA-pinned action still functions)
- [ ] Verify `dast-zap` job passes on next scheduled/manual run (SHA-pinned action still functions)
- [ ] Trigger a release to verify `sync-native-versions` still patches version files correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)