### PR TITLE
security: gitignore render.yaml, add sanitized example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,8 @@ Thumbs.db
 *.pfx
 secrets/
 
-# Render
+# Render deployment config (contains infrastructure details — use render.yaml.example)
+render.yaml
 .render-buildpacks.json
 
 # Local Claude Code files

--- a/render.yaml.example
+++ b/render.yaml.example
@@ -1,0 +1,79 @@
+services:
+  - type: web
+    name: <your-api-service-name>
+    env: python
+    region: <your-region>
+    plan: starter
+    buildCommand: pip install -r requirements.txt
+    startCommand: uvicorn app.main:app --host 0.0.0.0 --port $PORT
+    preDeployCommand: alembic upgrade head
+    healthCheckPath: /health
+    rootDir: backend
+    envVars:
+      - key: DATABASE_URL
+        fromDatabase:
+          name: <your-db-name>
+          property: connectionString
+      - key: ENVIRONMENT
+        value: production
+      - key: CORS_ORIGINS
+        value: '["https://<your-frontend-domain>"]'
+      - key: TRUSTED_HOSTS
+        value: '["<your-api-domain>"]'
+      - key: TURNSTILE_SECRET_KEY
+        sync: false
+      - key: SENTRY_DSN
+        sync: false
+
+  - type: web
+    name: <your-web-service-name>
+    env: static
+    region: <your-region>
+    branch: dev
+    buildCommand: npm ci && printf "EXPO_PUBLIC_API_URL=%s\nEXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=%s\nEXPO_PUBLIC_SENTRY_DSN=%s\nEXPO_PUBLIC_ENVIRONMENT=%s\n" "$EXPO_PUBLIC_API_URL" "$EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID" "$EXPO_PUBLIC_SENTRY_DSN" "$EXPO_PUBLIC_ENVIRONMENT" > .env && npx expo export --platform web --clear
+    staticPublishPath: dist
+    rootDir: frontend
+    pullRequestPreviewsEnabled: false
+    routes:
+      - type: rewrite
+        source: /*
+        destination: /index.html
+    headers:
+      - path: /*
+        name: Cross-Origin-Opener-Policy
+        value: same-origin-allow-popups
+      - path: /*
+        name: X-Frame-Options
+        value: DENY
+      - path: /*
+        name: X-Content-Type-Options
+        value: nosniff
+      - path: /*
+        name: Referrer-Policy
+        value: strict-origin-when-cross-origin
+      - path: /*
+        name: Strict-Transport-Security
+        value: 'max-age=31536000; includeSubDomains'
+      - path: /*
+        name: Content-Security-Policy
+        value: "default-src 'self'; img-src 'self' https: data:; connect-src 'self' https://<your-api-domain>; style-src 'self' 'unsafe-inline'; script-src 'self'"
+      - path: /*
+        name: Cache-Control
+        value: no-cache
+      - path: /assets/*
+        name: Cache-Control
+        value: 'public, max-age=31536000, immutable'
+    envVars:
+      - key: EXPO_PUBLIC_API_URL
+        value: https://<your-api-domain>
+      - key: EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID
+        sync: false
+      - key: EXPO_PUBLIC_SENTRY_DSN
+        sync: false
+      - key: EXPO_PUBLIC_ENVIRONMENT
+        value: development
+
+databases:
+  - name: <your-db-name>
+    plan: basic-256mb
+    region: <your-region>


### PR DESCRIPTION
## Summary

- Adds `render.yaml` to `.gitignore` to prevent infrastructure details from being committed to the public repo
- Adds `render.yaml.example` with all sensitive values replaced by `<placeholder>` strings

## Security advisory

Resolves GHSA-878q-r78v-xxq2 — `render.yaml` exposed DB name, service names, domain names, region, and CSP details in the public repository.

## Note

After merging, run `git filter-repo --path render.yaml --invert-paths` to purge `render.yaml` from git history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)