### PR TITLE
chore(deps): bump pytest-asyncio from 1.3.0 to 1.4.0

### DIFF
--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 pytest==9.0.3
-pytest-asyncio==1.3.0
+pytest-asyncio==1.4.0
 pytest-cov==7.1.0
 pytest-benchmark==5.2.3
 black==26.5.1


### PR DESCRIPTION
## Summary
- Bumps `pytest-asyncio` from `1.3.0` to `1.4.0` in `backend/requirements-dev.txt`
- This was the sole net-new change from dependabot PR #342, which was closed because the group bump included `fastapi@0.136.3` (MAL-2026-4750 malware advisory — no fix version; held at 0.136.1)

## Test plan
- [ ] Backend pip-audit passes (no vulnerabilities in requirements)
- [ ] Backend tests pass with pytest-asyncio 1.4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)