### PR TITLE
fix(deps): pin @sentry/react-native to ~7.11.0 for Expo SDK 56 compat

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -71,6 +71,13 @@ updates:
           - "version-update:semver-minor"
       - dependency-name: "react"
         update-types: ["version-update:semver-major"]
+      # Expo SDK 56 compatibility matrix requires ~7.11.0 — block all bumps until
+      # Expo explicitly supports a newer major.
+      - dependency-name: "@sentry/react-native"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     labels:
       - "dependencies"
       - "frontend"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,7 +13,7 @@
         "@expo/vector-icons": "^15.0.2",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-community/netinfo": "12.0.1",
-        "@sentry/react-native": "~8.14.0",
+        "@sentry/react-native": "~7.11.0",
         "@tanstack/react-query": "^5.100.10",
         "axios": "^1.15.2",
         "expo": "~56.0.12",
@@ -4458,126 +4458,127 @@
       "license": "MIT"
     },
     "node_modules/@sentry-internal/browser-utils": {
-      "version": "10.57.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.57.0.tgz",
-      "integrity": "sha512-tXObp954rMTSYKlbftjVXHtNl4t/6ssks3jkqyzmKb+PDPWzabGQO7sWwqVuTjT8Kx/8A3FmriS1bGmqxiJy3A==",
+      "version": "10.37.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.37.0.tgz",
+      "integrity": "sha512-rqdESYaVio9Ktz55lhUhtBsBUCF3wvvJuWia5YqoHDd+egyIfwWxITTAa0TSEyZl7283A4WNHNl0hyeEMblmfA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.57.0"
+        "@sentry/core": "10.37.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/feedback": {
-      "version": "10.57.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.57.0.tgz",
-      "integrity": "sha512-ZcF4QhkqGX3iiQSXB2N0N3Awp+j5iqnDRu6PA/qyLFrWqH5ZiiAAgu59OLD9E6XAdg6iFtLYw19MAMZVK8qNOQ==",
+      "version": "10.37.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.37.0.tgz",
+      "integrity": "sha512-P0PVlfrDvfvCYg2KPIS7YUG/4i6ZPf8z1MicXx09C9Cz9W9UhSBh/nii13eBdDtLav2BFMKhvaFMcghXHX03Hw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.57.0"
+        "@sentry/core": "10.37.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay": {
-      "version": "10.57.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.57.0.tgz",
-      "integrity": "sha512-Wmnx/6ABynVH1iwuoNUqJNyjIUqsqoGML7qsyivBRKb5Wo2YQtPOQlQYfxfZSvWzGpcoSVdInkRjDssUQxQEQg==",
+      "version": "10.37.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.37.0.tgz",
+      "integrity": "sha512-snuk12ZaDerxesSnetNIwKoth/51R0y/h3eXD/bGtXp+hnSkeXN5HanI/RJl297llRjn4zJYRShW9Nx86Ay0Dw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "10.57.0",
-        "@sentry/core": "10.57.0"
+        "@sentry-internal/browser-utils": "10.37.0",
+        "@sentry/core": "10.37.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
-      "version": "10.57.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.57.0.tgz",
-      "integrity": "sha512-zsfa4JcfV0AEc9YhNxNabd5lSZL2Av84saAyexGAqcHs+67m9Gd0cGStOzMb/nCl7UAtmdP0aI+G7a3rcxxN/A==",
+      "version": "10.37.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.37.0.tgz",
+      "integrity": "sha512-PyIYSbjLs+L5essYV0MyIsh4n5xfv2eV7l0nhUoPJv9Bak3kattQY3tholOj0EP3SgKgb+8HSZnmazgF++Hbog==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/replay": "10.57.0",
-        "@sentry/core": "10.57.0"
+        "@sentry-internal/replay": "10.37.0",
+        "@sentry/core": "10.37.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/babel-plugin-component-annotate": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-5.3.0.tgz",
-      "integrity": "sha512-p4q8gn8wcFqZGP/s2MnJCAAd8fTikaU6A0mM97RDHQgStcrYiaS0Sc5zUNfb1V+UOLPuvdEdL6MwyxfzjYJQTA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-4.8.0.tgz",
+      "integrity": "sha512-cy/9Eipkv23MsEJ4IuB4dNlVwS9UqOzI3Eu+QPake5BVFgPYCX0uP0Tr3Z43Ime6Rb+BiDnWC51AJK9i9afHYw==",
       "license": "MIT",
       "engines": {
-        "node": ">= 18"
+        "node": ">= 14"
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "10.57.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.57.0.tgz",
-      "integrity": "sha512-s36AQy/CKXTfyY9Z+qUhzNomntZXgfs0rbaK7q9ffnFkqcPwzE8qQtVs58y3Suut56u+AhwSztgQtERcuZ5VIA==",
+      "version": "10.37.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.37.0.tgz",
+      "integrity": "sha512-kheqJNqGZP5TSBCPv4Vienv1sfZwXKHQDYR+xrdHHYdZqwWuZMJJW/cLO9XjYAe+B9NnJ4UwJOoY4fPvU+HQ1Q==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "10.57.0",
-        "@sentry-internal/feedback": "10.57.0",
-        "@sentry-internal/replay": "10.57.0",
-        "@sentry-internal/replay-canvas": "10.57.0",
-        "@sentry/core": "10.57.0"
+        "@sentry-internal/browser-utils": "10.37.0",
+        "@sentry-internal/feedback": "10.37.0",
+        "@sentry-internal/replay": "10.37.0",
+        "@sentry-internal/replay-canvas": "10.37.0",
+        "@sentry/core": "10.37.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/cli": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-3.5.0.tgz",
-      "integrity": "sha512-D3N3kULOnAClRkhHKqOAcOTtDnRe7hFacdHLlSsQXAZB11Qu6VAy8mGmM3654Lq/3LHl5h8CW590JGR9E0yahQ==",
+      "version": "2.58.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.58.4.tgz",
+      "integrity": "sha512-ArDrpuS8JtDYEvwGleVE+FgR+qHaOp77IgdGSacz6SZy6Lv90uX0Nu4UrHCQJz8/xwIcNxSqnN22lq0dH4IqTg==",
       "hasInstallScript": true,
       "license": "FSL-1.1-MIT",
       "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.7",
         "progress": "^2.0.3",
         "proxy-from-env": "^1.1.0",
-        "undici": "^6.22.0",
         "which": "^2.0.2"
       },
       "bin": {
         "sentry-cli": "bin/sentry-cli"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 10"
       },
       "optionalDependencies": {
-        "@sentry/cli-darwin": "3.5.0",
-        "@sentry/cli-linux-arm": "3.5.0",
-        "@sentry/cli-linux-arm64": "3.5.0",
-        "@sentry/cli-linux-i686": "3.5.0",
-        "@sentry/cli-linux-x64": "3.5.0",
-        "@sentry/cli-win32-arm64": "3.5.0",
-        "@sentry/cli-win32-i686": "3.5.0",
-        "@sentry/cli-win32-x64": "3.5.0"
+        "@sentry/cli-darwin": "2.58.4",
+        "@sentry/cli-linux-arm": "2.58.4",
+        "@sentry/cli-linux-arm64": "2.58.4",
+        "@sentry/cli-linux-i686": "2.58.4",
+        "@sentry/cli-linux-x64": "2.58.4",
+        "@sentry/cli-win32-arm64": "2.58.4",
+        "@sentry/cli-win32-i686": "2.58.4",
+        "@sentry/cli-win32-x64": "2.58.4"
       }
     },
     "node_modules/@sentry/cli-darwin": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-3.5.0.tgz",
-      "integrity": "sha512-Q7WIq+SNMh/7gddovgcHUBlgzsH2jASdkxinwxoDZVNcF96gqr35QllRHkxZTt1+nLM3JytL2A+Mh9JdvMWzsA==",
+      "version": "2.58.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.58.4.tgz",
+      "integrity": "sha512-kbTD+P4X8O+nsNwPxCywtj3q22ecyRHWff98rdcmtRrvwz8CKi/T4Jxn/fnn2i4VEchy08OWBuZAqaA5Kh2hRQ==",
       "license": "FSL-1.1-MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
       "engines": {
-        "node": ">=18"
+        "node": ">=10"
       }
     },
     "node_modules/@sentry/cli-linux-arm": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-3.5.0.tgz",
-      "integrity": "sha512-d4U64gQikZiqr63XL3suWhd28e0NQg63GX+JumRiDYCDCAF3gmdUS6BRR43lyoZm2wqhHRQSms2bMArAPTDH/w==",
+      "version": "2.58.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.58.4.tgz",
+      "integrity": "sha512-rdQ8beTwnN48hv7iV7e7ZKucPec5NJkRdrrycMJMZlzGBPi56LqnclgsHySJ6Kfq506A2MNuQnKGaf/sBC9REA==",
       "cpu": [
         "arm"
       ],
@@ -4589,13 +4590,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=18"
+        "node": ">=10"
       }
     },
     "node_modules/@sentry/cli-linux-arm64": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-3.5.0.tgz",
-      "integrity": "sha512-nWlWo0qw1OqcOFR6GgcJ3KT+bMOlE3BFBtbMCxyURb4dTcT+NPy1Oe9Kk+JyWgRk1xm4CTaPXJNd2JD5V36FQA==",
+      "version": "2.58.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.58.4.tgz",
+      "integrity": "sha512-0g0KwsOozkLtzN8/0+oMZoOuQ0o7W6O+hx+ydVU1bktaMGKEJLMAWxOQNjsh1TcBbNIXVOKM/I8l0ROhaAb8Ig==",
       "cpu": [
         "arm64"
       ],
@@ -4607,13 +4608,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=18"
+        "node": ">=10"
       }
     },
     "node_modules/@sentry/cli-linux-i686": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-3.5.0.tgz",
-      "integrity": "sha512-HE8zFNvg/YWudGp+pBeJSNgF/siyarnlBkWbRxz6WApsFq7uvajXPk7EqwJ0onKnzPS14OPlTtTejA3iSUuCNg==",
+      "version": "2.58.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.58.4.tgz",
+      "integrity": "sha512-NseoIQAFtkziHyjZNPTu1Gm1opeQHt7Wm1LbLrGWVIRvUOzlslO9/8i6wETUZ6TjlQxBVRgd3Q0lRBG2A8rFYA==",
       "cpu": [
         "x86",
         "ia32"
@@ -4626,13 +4627,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=18"
+        "node": ">=10"
       }
     },
     "node_modules/@sentry/cli-linux-x64": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-3.5.0.tgz",
-      "integrity": "sha512-uU6h/b3SIoWysn0U6PoyUx/R5z9kU9+VcuvydjlqkZGDbbcRIxqp0T/wgB/jhXeFaSSPSFlmmkQCVYi8PXCrSw==",
+      "version": "2.58.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.58.4.tgz",
+      "integrity": "sha512-d3Arz+OO/wJYTqCYlSN3Ktm+W8rynQ/IMtSZLK8nu0ryh5mJOh+9XlXY6oDXw4YlsM8qCRrNquR8iEI1Y/IH+Q==",
       "cpu": [
         "x64"
       ],
@@ -4644,13 +4645,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=18"
+        "node": ">=10"
       }
     },
     "node_modules/@sentry/cli-win32-arm64": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-3.5.0.tgz",
-      "integrity": "sha512-P13w9Vc/ur6rnwtiBe4wzu4M81ODhdOGc8iWpkN51gzjldjz9FF4F2UEdS9UUYBxesWJU+UF62ZVQ4H73rhS4g==",
+      "version": "2.58.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.58.4.tgz",
+      "integrity": "sha512-bqYrF43+jXdDBh0f8HIJU3tbvlOFtGyRjHB8AoRuMQv9TEDUfENZyCelhdjA+KwDKYl48R1Yasb4EHNzsoO83w==",
       "cpu": [
         "arm64"
       ],
@@ -4660,13 +4661,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=18"
+        "node": ">=10"
       }
     },
     "node_modules/@sentry/cli-win32-i686": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-3.5.0.tgz",
-      "integrity": "sha512-LZIEsJ5zMd0HAYlnG7G7OM6/AOvFaWkuBPdePZqYvtMLOUsfY7zeW8ubyZ9uCOWsj5Xc7UiDF4v0gZ45Strlkg==",
+      "version": "2.58.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.58.4.tgz",
+      "integrity": "sha512-3triFD6jyvhVcXOmGyttf+deKZcC1tURdhnmDUIBkiDPJKGT/N5xa4qAtHJlAB/h8L9jgYih9bvJnvvFVM7yug==",
       "cpu": [
         "x86",
         "ia32"
@@ -4677,13 +4678,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=18"
+        "node": ">=10"
       }
     },
     "node_modules/@sentry/cli-win32-x64": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-3.5.0.tgz",
-      "integrity": "sha512-Dgkn60xoF7csXcKk+gRlmOA7s//7w0R3QlaXCo5RbX/c5VTbcV74r6ON7A+SKTFO9i4fEGblLlzQ0MLqrIo2sw==",
+      "version": "2.58.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.58.4.tgz",
+      "integrity": "sha512-cSzN4PjM1RsCZ4pxMjI0VI7yNCkxiJ5jmWncyiwHXGiXrV1eXYdQ3n1LhUYLZ91CafyprR0OhDcE+RVZ26Qb5w==",
       "cpu": [
         "x64"
       ],
@@ -4693,53 +4694,26 @@
         "win32"
       ],
       "engines": {
-        "node": ">=18"
+        "node": ">=10"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "10.57.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.57.0.tgz",
-      "integrity": "sha512-kntItTA2kiT0YpL7encXaF6mkdZMB+y48lwj8w1wkfBpfJAC7sifdgrzLQZqmsqVNE3crg9VfufaAGA+78uFMg==",
+      "version": "10.37.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.37.0.tgz",
+      "integrity": "sha512-hkRz7S4gkKLgPf+p3XgVjVm7tAfvcEPZxeACCC6jmoeKhGkzN44nXwLiqqshJ25RMcSrhfFvJa/FlBg6zupz7g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@sentry/expo-upload-sourcemaps": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/@sentry/expo-upload-sourcemaps/-/expo-upload-sourcemaps-8.14.0.tgz",
-      "integrity": "sha512-caPp11nVIAHtCTaM2kTqf3wG5aAui09EbeqoBEA9//NnRkuOVuRqapfX+ABTFlnnimbBSvn3MKrQt6HTMp/ELQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/cli": "3.5.0"
-      },
-      "bin": {
-        "expo-upload-sourcemaps": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@expo/env": "*",
-        "dotenv": "*"
-      },
-      "peerDependenciesMeta": {
-        "@expo/env": {
-          "optional": true
-        },
-        "dotenv": {
-          "optional": true
-        }
       }
     },
     "node_modules/@sentry/react": {
-      "version": "10.57.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.57.0.tgz",
-      "integrity": "sha512-6QThwQ4XWQ2rwKZEVQ9P9WKl7JlowC7S5LpAvmMdrwlfJBpLDFOsM7tycnIvbXTXf0ZOOuLFPa4L4YYbdyNGmA==",
+      "version": "10.37.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.37.0.tgz",
+      "integrity": "sha512-XLnXJOHgsCeVAVBbO+9AuGlZWnCxLQHLOmKxpIr8wjE3g7dHibtug6cv8JLx78O4dd7aoCqv2TTyyKY9FLJ2EQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "10.57.0",
-        "@sentry/core": "10.57.0"
+        "@sentry/browser": "10.37.0",
+        "@sentry/core": "10.37.0"
       },
       "engines": {
         "node": ">=18"
@@ -4749,22 +4723,19 @@
       }
     },
     "node_modules/@sentry/react-native": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-8.14.0.tgz",
-      "integrity": "sha512-2OF5M1Easgo25qX5360I/zb/P8IPhu6YXTgvCQCA6AYHxZvLf/9w/Rzaa+BYl6wBnnUvserjtua1xXdSrQhQXA==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-7.11.0.tgz",
+      "integrity": "sha512-OiDaLCAGpRN18YG/o7IIwLhU0Xpb0tYKQ5QxkGHiwb+L3VHn+MqGCGfITYNdhqr06HHMvu9Lysm+UJxaNmGaJg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/babel-plugin-component-annotate": "5.3.0",
-        "@sentry/browser": "10.57.0",
-        "@sentry/cli": "3.5.0",
-        "@sentry/core": "10.57.0",
-        "@sentry/expo-upload-sourcemaps": "8.14.0",
-        "@sentry/react": "10.57.0"
+        "@sentry/babel-plugin-component-annotate": "4.8.0",
+        "@sentry/browser": "10.37.0",
+        "@sentry/cli": "2.58.4",
+        "@sentry/core": "10.37.0",
+        "@sentry/react": "10.37.0",
+        "@sentry/types": "10.37.0"
       },
       "bin": {
-        "sentry-eas-build-on-complete": "scripts/eas-build-hook.js",
-        "sentry-eas-build-on-error": "scripts/eas-build-hook.js",
-        "sentry-eas-build-on-success": "scripts/eas-build-hook.js",
         "sentry-expo-upload-sourcemaps": "scripts/expo-upload-sourcemaps.js"
       },
       "peerDependencies": {
@@ -4776,6 +4747,18 @@
         "expo": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@sentry/types": {
+      "version": "10.37.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-10.37.0.tgz",
+      "integrity": "sha512-umpnUKRC0AAbJrADg6SlFtqN2yzf7NHciCF9lkHau+ax2PIZ/NDmoG4RQujFVflVaVoD60Ly2t+CcPnYIWMPlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.37.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sideway/address": {
@@ -9604,33 +9587,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/expo/node_modules/react-native-worklets": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.8.3.tgz",
-      "integrity": "sha512-oCBJROyLU7yG/1R8s0INMflygTH71bx+5XcYkH0CM938TlhSoVbiunE1WVW5FZa51vwYqfLie/IXMX2s1Kh3eg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/plugin-transform-arrow-functions": "^7.27.1",
-        "@babel/plugin-transform-class-properties": "^7.27.1",
-        "@babel/plugin-transform-classes": "^7.28.4",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1",
-        "@babel/plugin-transform-optional-chaining": "^7.27.1",
-        "@babel/plugin-transform-shorthand-properties": "^7.27.1",
-        "@babel/plugin-transform-template-literals": "^7.27.1",
-        "@babel/plugin-transform-unicode-regex": "^7.27.1",
-        "@babel/preset-typescript": "^7.27.1",
-        "convert-source-map": "^2.0.0",
-        "semver": "^7.7.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "*",
-        "@react-native/metro-config": "*",
-        "react": "*",
-        "react-native": "0.81 - 0.85"
-      }
-    },
     "node_modules/expo/node_modules/react-refresh": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
@@ -10116,7 +10072,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -17261,15 +17216,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9587,6 +9587,33 @@
         "node": ">=4"
       }
     },
+    "node_modules/expo/node_modules/react-native-worklets": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.8.3.tgz",
+      "integrity": "sha512-oCBJROyLU7yG/1R8s0INMflygTH71bx+5XcYkH0CM938TlhSoVbiunE1WVW5FZa51vwYqfLie/IXMX2s1Kh3eg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/plugin-transform-arrow-functions": "^7.27.1",
+        "@babel/plugin-transform-class-properties": "^7.27.1",
+        "@babel/plugin-transform-classes": "^7.28.4",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1",
+        "@babel/plugin-transform-optional-chaining": "^7.27.1",
+        "@babel/plugin-transform-shorthand-properties": "^7.27.1",
+        "@babel/plugin-transform-template-literals": "^7.27.1",
+        "@babel/plugin-transform-unicode-regex": "^7.27.1",
+        "@babel/preset-typescript": "^7.27.1",
+        "convert-source-map": "^2.0.0",
+        "semver": "^7.7.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "*",
+        "@react-native/metro-config": "*",
+        "react": "*",
+        "react-native": "0.81 - 0.85"
+      }
+    },
     "node_modules/expo/node_modules/react-refresh": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
@@ -10072,6 +10099,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,7 @@
     "@expo/vector-icons": "^15.0.2",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/netinfo": "12.0.1",
-    "@sentry/react-native": "~8.14.0",
+    "@sentry/react-native": "~7.11.0",
     "@tanstack/react-query": "^5.100.10",
     "axios": "^1.15.2",
     "expo": "~56.0.12",


### PR DESCRIPTION
## Summary

- Reverts `@sentry/react-native` from `~8.14.0` (Dependabot PR #365) back to `~7.11.0`
- Expo SDK 56's compatibility matrix requires `~7.11.0`; v8.x breaks the `expo-compat` CI check
- Adds a full Dependabot ignore rule for `@sentry/react-native` (all semver levels) so it won't be auto-bumped until Expo explicitly supports a newer major

## Root cause

Dependabot PR #365 bumped `@sentry/react-native` to `8.14.0`. The `expo-compat` CI job runs `npx expo install --check`, which flags anything outside Expo's compatibility matrix. SDK 56 expects `~7.11.0`, so every bump past that fails the check. This was reverting (commit `86d812b`) once before for SDK 55; same constraint applies on SDK 56.

## Test plan

- [x] `frontend/package-lock.json` locked to `@sentry/react-native@7.11.0`
- [ ] `expo-compat` CI check passes on this PR
- [ ] All other CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)